### PR TITLE
자동 정비 기능 5종 추가 (Issue 자동 close, 셀렉터 장애 감지, 키워드 후보 추천 등)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ WINDOW_HOURS=24
 WINDOW_END_HOUR_KST=9
 WINDOW_END_MINUTE_KST=30
 
+# 브리핑 Issue 자동 close: 생성된 지 N일 지난 Issue를 매 실행마다 정리
+ISSUE_KEEP_DAYS=30
+
 # 로그 레벨
 LOG_LEVEL=INFO
 

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -48,6 +48,7 @@ jobs:
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
           WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '9' }}
           WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '30' }}
+          ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # GITHUB_REPOSITORY is auto-set by the runner; GITHUB_TOKEN must be passed explicitly.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/briefing/cleanup.py
+++ b/briefing/cleanup.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+log = logging.getLogger(__name__)
+
+GITHUB_API = "https://api.github.com"
+BRIEFING_TITLE_PREFIX = "[일일 브리핑]"
+
+
+def close_old_briefings(*, days: int = 30) -> int:
+    """`days`일 이상 지난 브리핑 Issue를 자동 close. 닫은 개수 반환."""
+    repo = os.getenv("GITHUB_REPOSITORY")
+    token = os.getenv("GITHUB_TOKEN")
+    if not repo or not token:
+        log.warning("cleanup skipped: GITHUB_REPOSITORY/GITHUB_TOKEN missing")
+        return 0
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    closed = 0
+
+    page = 1
+    while True:
+        list_url = f"{GITHUB_API}/repos/{repo}/issues"
+        params = {"state": "open", "per_page": 100, "page": page, "sort": "created", "direction": "asc"}
+        try:
+            res = requests.get(list_url, headers=headers, params=params, timeout=30)
+            res.raise_for_status()
+        except requests.RequestException:
+            log.exception("cleanup: list issues failed")
+            return closed
+        items = res.json()
+        if not items:
+            break
+
+        for issue in items:
+            # PR도 issues 엔드포인트로 잡히므로 제외
+            if "pull_request" in issue:
+                continue
+            title = issue.get("title", "")
+            if not title.startswith(BRIEFING_TITLE_PREFIX):
+                continue
+            created_at_str = issue.get("created_at")
+            if not created_at_str:
+                continue
+            try:
+                created_at = datetime.fromisoformat(created_at_str.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if created_at >= cutoff:
+                # sort=created/asc 이므로 이후 항목도 모두 cutoff 이내
+                return closed
+
+            number = issue["number"]
+            patch_url = f"{GITHUB_API}/repos/{repo}/issues/{number}"
+            try:
+                res2 = requests.patch(
+                    patch_url, headers=headers, json={"state": "closed"}, timeout=30
+                )
+                res2.raise_for_status()
+                closed += 1
+                log.info("cleanup: closed issue #%s (%s)", number, title)
+            except requests.RequestException:
+                log.exception("cleanup: failed to close #%s", number)
+
+        if len(items) < 100:
+            break
+        page += 1
+
+    return closed

--- a/briefing/main.py
+++ b/briefing/main.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from . import hikorea, publisher, scraper, storage, summarizer  # noqa: E402
+from . import cleanup, hikorea, publisher, scraper, storage, summarizer  # noqa: E402
 from .config import ensure_dirs  # noqa: E402
 
 logging.basicConfig(
@@ -25,12 +25,17 @@ def run(*, dry_run: bool = False) -> int:
     article_briefings: list[publisher.ArticleBriefing] = []
     seen_urls: set[tuple[str, str]] = set()
 
-    log.info("Step 1/3: scraping press releases")
-    articles = scraper.fetch_all()
-    log.info("  fetched %d candidate articles (after keyword filter)", len(articles))
+    log.info("Step 1/4: scraping press releases")
+    scrape_result = scraper.fetch_all()
+    log.info(
+        "  fetched %d matched / %d unmatched candidates / %d errors",
+        len(scrape_result.articles),
+        len(scrape_result.unmatched_candidates),
+        len(scrape_result.errors),
+    )
 
     with storage.connect() as conn:
-        for art in articles:
+        for art in scrape_result.articles:
             key = (art.site, art.url)
             if key in seen_urls or storage.is_article_seen(conn, art.site, art.url):
                 continue
@@ -51,7 +56,7 @@ def run(*, dry_run: bool = False) -> int:
                 )
             )
 
-        log.info("Step 2/3: monitoring HiKorea attachments")
+        log.info("Step 2/4: monitoring HiKorea attachments")
         hikorea_briefings: list[publisher.HikoreaBriefing] = []
         changes = hikorea.check_all(conn)
         log.info("  detected %d file changes", len(changes))
@@ -72,18 +77,32 @@ def run(*, dry_run: bool = False) -> int:
                 )
             )
 
+    log.info("Step 3/4: scanning unmatched titles for keyword candidates")
+    keyword_candidates_md = ""
+    if scrape_result.unmatched_candidates:
+        keyword_candidates_md = summarizer.suggest_keywords(
+            scrape_result.unmatched_candidates
+        )
+        log.info(
+            "  keyword suggestions: %s",
+            "found" if keyword_candidates_md else "none",
+        )
+
     log.info(
-        "Step 3/3: publishing GitHub Issue (articles=%d, hikorea=%d)",
+        "Step 4/4: publishing GitHub Issue (articles=%d, hikorea=%d, errors=%d, candidates=%s)",
         len(article_briefings),
         len(hikorea_briefings),
+        len(scrape_result.errors),
+        "yes" if keyword_candidates_md else "no",
     )
-    if not article_briefings and not hikorea_briefings:
-        log.info("새 업데이트가 없지만, 모니터링 정상 동작 확인용으로 빈 브리핑을 게시합니다.")
 
     if dry_run:
         title, body = publisher.render_markdown(
             articles=article_briefings,
             hikorea_changes=hikorea_briefings,
+            scrape_errors=scrape_result.errors,
+            keyword_candidates_md=keyword_candidates_md,
+            mention_handle=os.getenv("GITHUB_REPOSITORY", "/").split("/")[0] or None,
         )
         print("=" * 60)
         print("TITLE:", title)
@@ -94,7 +113,20 @@ def run(*, dry_run: bool = False) -> int:
     ok = publisher.publish(
         articles=article_briefings,
         hikorea_changes=hikorea_briefings,
+        scrape_errors=scrape_result.errors,
+        keyword_candidates_md=keyword_candidates_md,
     )
+
+    # 오래된 브리핑 Issue 자동 close (기본 30일)
+    if ok:
+        try:
+            keep_days = int(os.getenv("ISSUE_KEEP_DAYS", "30"))
+            n_closed = cleanup.close_old_briefings(days=keep_days)
+            if n_closed:
+                log.info("auto-closed %d old briefing issue(s)", n_closed)
+        except Exception:  # noqa: BLE001
+            log.exception("issue cleanup failed (non-fatal)")
+
     return 0 if ok else 1
 
 

--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -40,6 +40,9 @@ def render_markdown(
     *,
     articles: list[ArticleBriefing],
     hikorea_changes: list[HikoreaBriefing],
+    scrape_errors: list[tuple[str, str]] | None = None,
+    keyword_candidates_md: str = "",
+    mention_handle: str | None = None,
 ) -> tuple[str, str]:
     today = datetime.now(KST).strftime("%Y-%m-%d")
     title = f"[일일 브리핑] 이민·비자 정책 동향 ({today})"
@@ -74,8 +77,35 @@ def render_markdown(
         lines.append("> 하이코리아 추적 게시글에 변동 사항이 없습니다.")
         lines.append("")
 
+    if scrape_errors:
+        lines.append("## ⚠️ 모니터링 경고")
+        lines.append("")
+        for site, msg in scrape_errors:
+            lines.append(f"- **{site}**: {msg}")
+        lines.append("")
+        lines.append(
+            "_조치: `briefing/config.py` 의 `SITES` 항목에서 해당 사이트의 셀렉터를 점검하세요._"
+        )
+        lines.append("")
+
+    if keyword_candidates_md:
+        lines.append("## 🧐 키워드 후보 (수동 검토 권장)")
+        lines.append("")
+        lines.append(
+            "_현재 키워드 사전엔 안 걸렸지만 정책 관련성이 의심되는 제목들입니다. "
+            "필요한 단어를 `briefing/config.py` 의 `KEYWORDS` 튜플에 추가하면 다음 실행부터 자동 포착됩니다._"
+        )
+        lines.append("")
+        lines.append(keyword_candidates_md)
+        lines.append("")
+
     lines.append("---")
     lines.append("_자동 생성 — `kaist9558/kaist9558.github.io` · briefing_")
+
+    has_content = bool(articles or hikorea_changes or scrape_errors or keyword_candidates_md)
+    if mention_handle and has_content:
+        lines.append("")
+        lines.append(f"cc @{mention_handle}")
 
     return title, "\n".join(lines)
 
@@ -84,8 +114,10 @@ def publish(
     *,
     articles: list[ArticleBriefing],
     hikorea_changes: list[HikoreaBriefing],
+    scrape_errors: list[tuple[str, str]] | None = None,
+    keyword_candidates_md: str = "",
 ) -> bool:
-    repo = os.getenv("GITHUB_REPOSITORY")  # auto-set in Actions: "owner/repo"
+    repo = os.getenv("GITHUB_REPOSITORY")
     token = os.getenv("GITHUB_TOKEN")
 
     if not repo or not token:
@@ -95,7 +127,14 @@ def publish(
         )
         return False
 
-    title, body = render_markdown(articles=articles, hikorea_changes=hikorea_changes)
+    owner = repo.split("/")[0] if "/" in repo else None
+    title, body = render_markdown(
+        articles=articles,
+        hikorea_changes=hikorea_changes,
+        scrape_errors=scrape_errors,
+        keyword_candidates_md=keyword_candidates_md,
+        mention_handle=owner,
+    )
 
     url = f"{GITHUB_API}/repos/{repo}/issues"
     headers = {

--- a/briefing/scraper.py
+++ b/briefing/scraper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Iterable
 from urllib.parse import urljoin
@@ -26,6 +26,20 @@ class Article:
     content: str
 
 
+@dataclass
+class ScrapeResult:
+    articles: list[Article] = field(default_factory=list)
+    # 키워드는 못 맞췄지만 윈도우엔 들어온 후보들 — 키워드 후보 추천에 사용.
+    unmatched_candidates: list[tuple[str, str, str]] = field(default_factory=list)
+    # ("법무부", "HTTP 503"), ("출입국·외국인정책본부", "no rows matched selectors") 등.
+    errors: list[tuple[str, str]] = field(default_factory=list)
+
+    def extend(self, other: "ScrapeResult") -> None:
+        self.articles.extend(other.articles)
+        self.unmatched_candidates.extend(other.unmatched_candidates)
+        self.errors.extend(other.errors)
+
+
 def _select_first(node: Tag, selector: str) -> Tag | None:
     for sel in (s.strip() for s in selector.split(",")):
         if not sel:
@@ -41,7 +55,6 @@ def _extract_date(node: Tag, selector: str | None) -> datetime | None:
         return None
     cell = _select_first(node, selector)
     if not cell:
-        # Fall back: scan all <td> for a date-shaped string.
         for td in node.find_all(["td", "span", "div"]):
             m = DATE_RE.search(td.get_text(" ", strip=True))
             if m:
@@ -73,21 +86,21 @@ def _extract_content(soup: BeautifulSoup, selector: str) -> str:
             text = node.get_text("\n", strip=True)
             if text:
                 return text
-    # Last resort: strip nav/footer/script then dump body text.
     for tag in soup.find_all(["script", "style", "nav", "header", "footer", "aside"]):
         tag.decompose()
     body = soup.find("body")
     return body.get_text("\n", strip=True) if body else ""
 
 
-def fetch_articles(
-    session, site: Site, *, max_rows: int = 15
-) -> list[Article]:
+def fetch_articles(session, site: Site, *, max_rows: int = 15) -> ScrapeResult:
+    result = ScrapeResult()
+
     res = get(session, site.list_url, encoding=site.encoding)
     if res is None:
-        return []
-    soup = BeautifulSoup(res.text, "lxml")
+        result.errors.append((site.name, "목록 페이지 접속 실패 (네트워크 또는 5xx)"))
+        return result
 
+    soup = BeautifulSoup(res.text, "lxml")
     rows: list[Tag] = []
     for sel in (s.strip() for s in site.row_selector.split(",")):
         if not sel:
@@ -96,14 +109,12 @@ def fetch_articles(
         if rows:
             break
     if not rows:
-        log.warning("[%s] no rows matched selectors on %s", site.name, site.list_url)
-        return []
+        msg = "목록 셀렉터 매칭 실패 — 사이트 구조가 변경됐을 가능성 (config.py의 row_selector 확인)"
+        log.warning("[%s] %s", site.name, msg)
+        result.errors.append((site.name, msg))
+        return result
 
-    articles: list[Article] = []
     window_start, window_end = compute_window()
-    # 보도자료는 일 단위 날짜만 제공되므로 date() 비교.
-    # 윈도우가 [어제 09:30, 오늘 09:30) 라면 어제·오늘 두 날짜의 글을 모두 후보로 본다.
-    # (오늘 09:30 이후 글이 함께 들어올 수 있으나, dedup 테이블이 다음 실행에서 중복 발송을 막음.)
     earliest_date = window_start.date()
     latest_date = window_end.date()
 
@@ -117,7 +128,6 @@ def fetch_articles(
 
         href = link["href"]
         if href.lower().startswith("javascript:"):
-            # Skip JS-only links — site likely needs a headless browser.
             continue
         url = urljoin(site.base_url + "/", href)
 
@@ -128,16 +138,16 @@ def fetch_articles(
                 continue
 
         if not _matches_keyword(title):
+            result.unmatched_candidates.append((site.name, title, url))
             continue
 
         detail_res = get(session, url, encoding=site.encoding)
         content = ""
         if detail_res is not None:
             detail_soup = BeautifulSoup(detail_res.text, "lxml")
-            content = _extract_content(detail_soup, site.detail_content_selector)
-            content = content[:4000]
+            content = _extract_content(detail_soup, site.detail_content_selector)[:4000]
 
-        articles.append(
+        result.articles.append(
             Article(
                 site=site.name,
                 title=title,
@@ -147,15 +157,16 @@ def fetch_articles(
             )
         )
 
-    return articles
+    return result
 
 
-def fetch_all(sites: Iterable[Site] = SITES) -> list[Article]:
+def fetch_all(sites: Iterable[Site] = SITES) -> ScrapeResult:
     session = make_session()
-    out: list[Article] = []
+    combined = ScrapeResult()
     for site in sites:
         try:
-            out.extend(fetch_articles(session, site))
-        except Exception:  # noqa: BLE001 - one site shouldn't kill the run
+            combined.extend(fetch_articles(session, site))
+        except Exception as exc:  # noqa: BLE001 - one site shouldn't kill the run
             log.exception("[%s] scrape failed", site.name)
-    return out
+            combined.errors.append((site.name, f"예외 발생: {type(exc).__name__}: {exc}"))
+    return combined

--- a/briefing/summarizer.py
+++ b/briefing/summarizer.py
@@ -37,6 +37,20 @@ DIFF_SYSTEM = """당신은 한국 이민·비자·외국인 정책 변경을 추
 - 출력은 변경 요약 본문만 포함하십시오. 머리말·맺음말 금지.
 """
 
+KEYWORD_SUGGEST_SYSTEM = """당신은 한국 이민·비자·외국인 정책 연구원의 키워드 사전 관리를 돕는 보조원입니다.
+정부 부처 보도자료 제목 목록을 받습니다. 이 중 **이민·비자·외국인·국적·체류·재외동포·외국인 인재 정책과 직접 관련 있다고 판단되는 제목만** 골라내십시오.
+
+판단 기준
+- 핵심 정책 (출입국·체류·국적·외국인 행정·재외동포·외국인 노동·외국인 학생 등): 포함
+- 단순 행사·홍보·인사 발령·일반 사회 정책: 제외
+
+출력 형식 (관련 있는 제목 1개당 정확히 한 줄, 다른 텍스트 금지)
+- "<제목>" → 추천 키워드: `<단어>` (한 줄 사유)
+
+관련 항목이 하나도 없으면 출력은 정확히 다음 한 줄:
+NONE
+"""
+
 
 @lru_cache(maxsize=1)
 def _client() -> anthropic.Anthropic:
@@ -131,3 +145,34 @@ def summarize_diff(*, file_name: str, old_text: str | None, new_text: str | None
         log.exception("Claude summarize_diff failed for: %s", file_name)
         return "(변경 요약 생성 실패 — 파일을 직접 비교하세요.)"
     return _extract_text(msg).strip()
+
+
+def suggest_keywords(candidates: list[tuple[str, str, str]], *, max_titles: int = 30) -> str:
+    """키워드 미매칭 제목들 중 정책 관련성 있는 후보를 식별.
+
+    candidates: list of (site_name, title, url)
+    Returns: Markdown 불릿 형식 문자열 (관련 항목 없으면 빈 문자열).
+    """
+    if not candidates:
+        return ""
+    sample = candidates[:max_titles]
+    lines = [f"- [{site}] {title}" for site, title, _ in sample]
+    user = (
+        "다음은 부처 보도자료 중 현재 키워드 사전(`이민/비자/외국인/...`)에는 안 걸렸지만 "
+        "윈도우 안에 게시된 제목 목록입니다. 정책 관련성을 평가해주세요.\n\n"
+        + "\n".join(lines)
+    )
+    try:
+        msg = _client().messages.create(
+            model=CLAUDE_MODEL,
+            max_tokens=1024,
+            system=_system_with_cache(KEYWORD_SUGGEST_SYSTEM),
+            messages=[{"role": "user", "content": user}],
+        )
+    except anthropic.APIError:
+        log.exception("Claude suggest_keywords failed")
+        return ""
+    text = _extract_text(msg).strip()
+    if text == "NONE" or not text:
+        return ""
+    return text


### PR DESCRIPTION
## 개요

이전 머지(#1) 이후 "자동 수행 안 되는 것" 5개 항목을 가능한 한 자동화한 자가 모니터링·정비 패치.

## 추가된 기능

### 1️⃣ Issue 자동 close
- `briefing/cleanup.py` 신규
- 매 실행 후 `[일일 브리핑]` 으로 시작하는 Issue 중 생성된 지 `ISSUE_KEEP_DAYS`(기본 30) 일 지난 것을 자동으로 close
- 검색용 본문은 그대로 보존 (close만 됨, 삭제 X)

### 2️⃣ 자동 푸시 (소유자 멘션)
- 콘텐츠가 있는 브리핑 본문 끝에 `cc @kaist9558` 자동 추가
- Watch 설정을 안 했어도 GitHub 알림이 도착 — 이메일/모바일 푸시 모두

### 3️⃣ 셀렉터 장애 자동 감지
- 사이트 접속 실패 / 셀렉터 매칭 실패 / 예외 발생 시 → 브리핑 Issue 본문에 **"⚠️ 모니터링 경고"** 섹션 자동 추가
- 어느 사이트가 깨졌고 어느 설정을 봐야 하는지 한눈에 보임

### 4️⃣ 키워드 후보 자동 탐지
- 윈도우엔 들어왔지만 키워드 사전엔 안 걸린 제목들을 1회 Claude 호출로 분류
- 정책 관련성 있는 후보를 **"🧐 키워드 후보"** 섹션에 추천 키워드와 사유 함께 노출
- 사람이 보고 `KEYWORDS` 튜플에 추가하면 다음 실행부터 자동 포착

### 5️⃣ 사이트 자동 발견
- 본질적으로 자동화 불가능 → 문서화로 대체

## 리팩터

- `scraper.fetch_all()` 의 반환 타입을 `list[Article]` → `ScrapeResult(articles, unmatched_candidates, errors)` 로 변경
- `publisher.publish()` 가 위 세 가지를 모두 받아 단일 Issue로 합성

## 신규 환경변수

- `ISSUE_KEEP_DAYS` (기본 `30`) — 자동 close 임계일

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_