### PR TITLE
법무부·출입국 셀렉터 보정 + 과기부 일시 비활성화

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -62,34 +62,39 @@ class Site:
     encoding: str | None = None
 
 
+# 법무부와 출입국·외국인정책본부는 같은 통합 CMS(artclLinkView/_artclTd*/_articleTable)를 사용.
+# 과기부(msit.go.kr)는 글 목록이 JS 렌더링으로 채워지는 SPA 형태라 정적 HTML 크롤링 불가 —
+# 현재는 비활성화. 추후 playwright 등 headless 브라우저 도입 시 재활성화.
 SITES: tuple[Site, ...] = (
     Site(
         name="법무부",
         list_url="https://www.moj.go.kr/moj/221/subview.do",
         base_url="https://www.moj.go.kr",
-        row_selector="table.board_list tbody tr, div.board_list table tbody tr, ul.board_list li",
-        title_link_selector="td.title a, td.subject a, a.title, .title a",
-        date_selector="td.date, td.reg_date, .date",
-        detail_content_selector="div.board_view, div.view_cont, .board_view_cont, .bbs_view",
+        row_selector="div._articleTable table tbody tr, table tbody tr",
+        title_link_selector="a.artclLinkView, td._artclTdTitle a",
+        date_selector="td._artclTdRdate",
+        detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
     Site(
         name="출입국·외국인정책본부",
         list_url="https://www.immigration.go.kr/immigration/1502/subview.do",
         base_url="https://www.immigration.go.kr",
-        row_selector="table tbody tr, div.board_list table tbody tr, ul.board_list li",
-        title_link_selector="td.title a, td.subject a, a.title, .title a, td a",
-        date_selector="td.date, td.reg_date, .date, td:nth-of-type(4)",
-        detail_content_selector="div.board_view, div.view_cont, .board_view_cont, .bbs_view, .view_content",
+        row_selector="div._articleTable table tbody tr, table tbody tr",
+        title_link_selector="a.artclLinkView, td._artclTdTitle a",
+        date_selector="td._artclTdRdate",
+        detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
-    Site(
-        name="과학기술정보통신부",
-        list_url="https://www.msit.go.kr/bbs/list.do?sCode=user&mPid=208&mId=307",
-        base_url="https://www.msit.go.kr",
-        row_selector="table.board_list tbody tr, div.board_list table tbody tr, table tbody tr",
-        title_link_selector="td.title a, td.subject a, a.title, .title a, td a",
-        date_selector="td.date, td.reg_date, .date",
-        detail_content_selector="div.board_view, div.view_cont, .board_view_cont, .bbs_view, .view_content",
-    ),
+    # TODO(msit): 과기부는 글 목록이 JS로 렌더링되는 구조 — 정적 HTML에 <table>이 없음.
+    # 재활성화 옵션: (1) playwright 도입, (2) 백엔드 AJAX 엔드포인트 직접 호출, (3) RSS 피드 활용.
+    # Site(
+    #     name="과학기술정보통신부",
+    #     list_url="https://www.msit.go.kr/bbs/list.do?sCode=user&mPid=208&mId=307",
+    #     base_url="https://www.msit.go.kr",
+    #     row_selector="...",
+    #     title_link_selector="...",
+    #     date_selector="...",
+    #     detail_content_selector="...",
+    # ),
 )
 
 


### PR DESCRIPTION
## 진단 결과 반영

[PR #6](https://github.com/kaist9558/kaist9558.github.io/pull/6)에서 추가한 `diagnose` 모드를 GitHub Actions 러너에서 실행해 얻은 실제 HTML 구조 결과를 반영.

## 변경 사항

### ✅ 법무부·출입국 — 정확한 셀렉터로 보정

두 사이트가 사실상 동일한 **정부 통합 CMS**를 사용하는 것이 확인됨 (`artclLinkView`/`_artclTd*`/`_articleTable` 클래스 체계 공유). 이전의 일반화된 추측 셀렉터 → 실제 발견된 정확한 셀렉터로 교체:

| 항목 | 이전 (추측) | 이후 (실측) |
|---|---|---|
| row | `table.board_list tbody tr, …` | `div._articleTable table tbody tr, table tbody tr` |
| title | `td.title a, …` | `a.artclLinkView, td._artclTdTitle a` |
| date | `td.date, td.reg_date, …` | `td._artclTdRdate` |
| body | `div.board_view, …` | `div.artclView, div._articleTable._mojView` |

진단 결과에서 두 사이트 각각 10개 row가 정확히 매칭됐고, 첫 글의 첫 `<a>` 텍스트가 실제 보도자료 제목이었음을 확인.

### ⚠️ 과기부 — 일시 비활성화

진단 결과 HTTP 200 응답에 `<table tbody tr>` 포함 0개. 19개 후보 셀렉터 모두 매칭 실패. **글 목록이 JS로 클라이언트 렌더링되는 SPA 형태**로 추정. 정적 HTTP 크롤링으론 닿을 수 없는 상태.

`SITES` 튜플에서 주석 처리하면서 향후 재활성화 옵션 3가지 명시:
1. Playwright(headless 브라우저) 도입 — CI 시간 +30s, 의존성 ~150MB
2. 내부 AJAX 엔드포인트 직접 호출 — 추가 분석 필요
3. RSS 피드 활용 — msit.go.kr이 RSS 제공 시

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_