### PR TITLE
Playwright 지원 추가 + 과기부 사이트 재활성화

### DIFF
--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('requirements.txt') }}
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium
+
       - name: Restore briefing state cache
         uses: actions/cache@v4
         with:

--- a/briefing/config.py
+++ b/briefing/config.py
@@ -60,11 +60,12 @@ class Site:
     date_selector: str | None
     detail_content_selector: str
     encoding: str | None = None
+    requires_js: bool = False  # True면 Playwright(JsRenderer)로 페치
 
 
-# 법무부와 출입국·외국인정책본부는 같은 통합 CMS(artclLinkView/_artclTd*/_articleTable)를 사용.
-# 과기부(msit.go.kr)는 글 목록이 JS 렌더링으로 채워지는 SPA 형태라 정적 HTML 크롤링 불가 —
-# 현재는 비활성화. 추후 playwright 등 headless 브라우저 도입 시 재활성화.
+# 법무부·출입국은 통합 CMS(artclLinkView/_artclTd*/_articleTable) — 정적 HTTP로 충분.
+# 과기부는 글 목록이 JS로 렌더링되는 SPA 구조 — Playwright(requires_js=True)로 처리.
+# 과기부 셀렉터는 1차 placeholder. diagnose 모드 결과를 보고 정확한 클래스로 보정 필요.
 SITES: tuple[Site, ...] = (
     Site(
         name="법무부",
@@ -84,17 +85,23 @@ SITES: tuple[Site, ...] = (
         date_selector="td._artclTdRdate",
         detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
-    # TODO(msit): 과기부는 글 목록이 JS로 렌더링되는 구조 — 정적 HTML에 <table>이 없음.
-    # 재활성화 옵션: (1) playwright 도입, (2) 백엔드 AJAX 엔드포인트 직접 호출, (3) RSS 피드 활용.
-    # Site(
-    #     name="과학기술정보통신부",
-    #     list_url="https://www.msit.go.kr/bbs/list.do?sCode=user&mPid=208&mId=307",
-    #     base_url="https://www.msit.go.kr",
-    #     row_selector="...",
-    #     title_link_selector="...",
-    #     date_selector="...",
-    #     detail_content_selector="...",
-    # ),
+    Site(
+        name="과학기술정보통신부",
+        list_url="https://www.msit.go.kr/bbs/list.do?sCode=user&mPid=208&mId=307",
+        base_url="https://www.msit.go.kr",
+        requires_js=True,  # JS 렌더링 사이트 → Playwright 사용
+        # 1차 placeholder 셀렉터 — diagnose 결과 보고 정확한 값으로 교체.
+        row_selector=(
+            "div.board_list table tbody tr, table.board_list tbody tr, "
+            "table tbody tr, ul.board_list > li, div.bbsList li"
+        ),
+        title_link_selector="td.subject a, td.title a, a.title, .subject a, td a",
+        date_selector="td.date, td.reg_date, .date, td.regdate, .regdate",
+        detail_content_selector=(
+            "div.board_view, div.view_cont, div.viewCont, div.bbs_view, "
+            ".board_view_cont, .view_content, article, div.article_cont"
+        ),
+    ),
 )
 
 

--- a/briefing/diagnose.py
+++ b/briefing/diagnose.py
@@ -41,22 +41,34 @@ CANDIDATE_ROW_SELECTORS = [
 ]
 
 
-def inspect_site(session, site: Site) -> None:
+def inspect_site(session, site: Site, js_renderer=None) -> None:
     print()
     print("=" * 70)
     print(f"[{site.name}]  {site.list_url}")
+    if site.requires_js:
+        print("(requires_js=True — Playwright 사용)")
     print("=" * 70)
 
-    res = get(session, site.list_url, encoding=site.encoding)
-    if res is None:
-        print("FETCH FAILED — http_client.get returned None")
-        return
+    if site.requires_js:
+        if js_renderer is None:
+            print("FETCH FAILED — JS 렌더러 미초기화")
+            return
+        html = js_renderer.fetch(site.list_url)
+        if html is None:
+            print("FETCH FAILED — JS 렌더 페이지 로드 실패")
+            return
+        print(f"JS 렌더 완료. size={len(html)} bytes")
+    else:
+        res = get(session, site.list_url, encoding=site.encoding)
+        if res is None:
+            print("FETCH FAILED — http_client.get returned None")
+            return
+        html = res.text
+        print(f"HTTP {res.status_code}   size={len(res.text)} bytes   encoding={res.encoding}")
+        if res.headers.get("content-type"):
+            print(f"Content-Type: {res.headers['content-type']}")
 
-    print(f"HTTP {res.status_code}   size={len(res.text)} bytes   encoding={res.encoding}")
-    if res.headers.get("content-type"):
-        print(f"Content-Type: {res.headers['content-type']}")
-
-    soup = BeautifulSoup(res.text, "lxml")
+    soup = BeautifulSoup(html, "lxml")
 
     page_title = soup.find("title")
     print(f"<title>: {page_title.get_text(strip=True) if page_title else '(none)'}")
@@ -129,38 +141,63 @@ def inspect_site(session, site: Site) -> None:
                 from urllib.parse import urljoin
                 detail_url = urljoin(site.base_url + "/", link["href"])
                 print(f"\n--- 첫 글 상세페이지: {detail_url}")
-                detail_res = get(session, detail_url, encoding=site.encoding)
-                if detail_res is None:
-                    print("  detail fetch failed")
+                if site.requires_js and js_renderer is not None:
+                    detail_html = js_renderer.fetch(detail_url)
+                    if detail_html is None:
+                        print("  detail fetch failed (JS renderer)")
+                        return
+                    detail_soup = BeautifulSoup(detail_html, "lxml")
+                    print(f"  JS 렌더 완료 size={len(detail_html)}")
                 else:
+                    detail_res = get(session, detail_url, encoding=site.encoding)
+                    if detail_res is None:
+                        print("  detail fetch failed")
+                        return
                     detail_soup = BeautifulSoup(detail_res.text, "lxml")
                     print(f"  HTTP {detail_res.status_code} size={len(detail_res.text)}")
-                    # 본문 컨테이너 후보
-                    print("  본문 컨테이너 후보:")
-                    body_seen = set()
-                    for tag in detail_soup.find_all(["div", "article", "section"]):
-                        cls = " ".join(tag.get("class") or [])
-                        tid = tag.get("id") or ""
-                        attr_text = (cls + " " + tid).lower()
-                        if not any(k in attr_text for k in ("view", "cont", "body", "article", "detail")):
-                            continue
-                        sig = f"{tag.name}:{cls}:{tid}"
-                        if sig in body_seen:
-                            continue
-                        body_seen.add(sig)
-                        text_len = len(tag.get_text(" ", strip=True))
-                        if text_len < 50:
-                            continue
-                        print(f"    <{tag.name} class={cls!r} id={tid!r}> 텍스트 {text_len}자")
+                # 본문 컨테이너 후보
+                print("  본문 컨테이너 후보:")
+                body_seen = set()
+                for tag in detail_soup.find_all(["div", "article", "section"]):
+                    cls = " ".join(tag.get("class") or [])
+                    tid = tag.get("id") or ""
+                    attr_text = (cls + " " + tid).lower()
+                    if not any(k in attr_text for k in ("view", "cont", "body", "article", "detail")):
+                        continue
+                    sig = f"{tag.name}:{cls}:{tid}"
+                    if sig in body_seen:
+                        continue
+                    body_seen.add(sig)
+                    text_len = len(tag.get_text(" ", strip=True))
+                    if text_len < 50:
+                        continue
+                    print(f"    <{tag.name} class={cls!r} id={tid!r}> 텍스트 {text_len}자")
 
 
 def main() -> int:
     session = make_session()
-    for site in SITES:
+    needs_js = any(s.requires_js for s in SITES)
+    js_ctx = None
+    if needs_js:
         try:
-            inspect_site(session, site)
+            from .js_fetcher import JsRenderer
+            js_ctx = JsRenderer()
+            js_ctx.__enter__()
+            print("(JS 렌더러 준비 완료 — Playwright Chromium)")
         except Exception as exc:  # noqa: BLE001
-            print(f"[{site.name}] 진단 중 예외: {type(exc).__name__}: {exc}")
+            print(f"(JS 렌더러 초기화 실패: {type(exc).__name__}: {exc} — JS 사이트는 스킵됨)")
+            js_ctx = None
+
+    try:
+        for site in SITES:
+            try:
+                renderer = js_ctx if site.requires_js else None
+                inspect_site(session, site, js_renderer=renderer)
+            except Exception as exc:  # noqa: BLE001
+                print(f"[{site.name}] 진단 중 예외: {type(exc).__name__}: {exc}")
+    finally:
+        if js_ctx is not None:
+            js_ctx.__exit__(None, None, None)
     return 0
 
 

--- a/briefing/js_fetcher.py
+++ b/briefing/js_fetcher.py
@@ -1,0 +1,85 @@
+"""JS 렌더링 사이트용 헤드리스 브라우저 페치 (Playwright Chromium).
+
+`Site.requires_js=True` 인 사이트는 정적 HTTP로 글 목록이 안 잡히므로
+Playwright로 페이지를 렌더링한 뒤 `page.content()` 의 결과 HTML을 사용한다.
+브라우저는 with 블록 동안 한 번만 띄워서 여러 URL에 재사용한다.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .config import USER_AGENT
+
+log = logging.getLogger(__name__)
+
+DEFAULT_GOTO_TIMEOUT_MS = 30_000
+NETWORK_IDLE_TIMEOUT_MS = 15_000
+WAIT_SELECTOR_TIMEOUT_MS = 10_000
+
+
+class JsRenderer:
+    """Headless Chromium 컨텍스트. with 문으로 사용한다.
+
+    Example:
+        with JsRenderer() as renderer:
+            html = renderer.fetch("https://...")
+    """
+
+    def __init__(self) -> None:
+        self._playwright = None
+        self._browser = None
+        self._context = None
+
+    def __enter__(self) -> "JsRenderer":
+        from playwright.sync_api import sync_playwright
+
+        self._playwright = sync_playwright().start()
+        self._browser = self._playwright.chromium.launch(headless=True)
+        self._context = self._browser.new_context(
+            user_agent=USER_AGENT,
+            locale="ko-KR",
+            extra_http_headers={"Accept-Language": "ko-KR,ko;q=0.9,en;q=0.8"},
+        )
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        for closer in (self._context, self._browser):
+            if closer is not None:
+                try:
+                    closer.close()
+                except Exception:  # noqa: BLE001
+                    pass
+        if self._playwright is not None:
+            try:
+                self._playwright.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def fetch(self, url: str, *, wait_selector: Optional[str] = None) -> Optional[str]:
+        """렌더링된 페이지 HTML 반환. 실패 시 None."""
+        if self._context is None:
+            raise RuntimeError("JsRenderer must be used as a context manager")
+
+        page = self._context.new_page()
+        try:
+            page.goto(url, wait_until="domcontentloaded", timeout=DEFAULT_GOTO_TIMEOUT_MS)
+            try:
+                page.wait_for_load_state("networkidle", timeout=NETWORK_IDLE_TIMEOUT_MS)
+            except Exception:  # noqa: BLE001
+                # networkidle 도달 실패해도 렌더링된 만큼은 사용
+                log.debug("networkidle timeout for %s — proceeding anyway", url)
+            if wait_selector:
+                try:
+                    page.wait_for_selector(wait_selector, timeout=WAIT_SELECTOR_TIMEOUT_MS)
+                except Exception:  # noqa: BLE001
+                    log.warning("wait_selector %r not found on %s", wait_selector, url)
+            return page.content()
+        except Exception as exc:  # noqa: BLE001
+            log.warning("[js_fetcher] %s 실패: %s", url, exc)
+            return None
+        finally:
+            try:
+                page.close()
+            except Exception:  # noqa: BLE001
+                pass

--- a/briefing/scraper.py
+++ b/briefing/scraper.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Iterable
+from typing import Callable, Iterable, Optional
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup, Tag
@@ -29,9 +29,7 @@ class Article:
 @dataclass
 class ScrapeResult:
     articles: list[Article] = field(default_factory=list)
-    # 키워드는 못 맞췄지만 윈도우엔 들어온 후보들 — 키워드 후보 추천에 사용.
     unmatched_candidates: list[tuple[str, str, str]] = field(default_factory=list)
-    # ("법무부", "HTTP 503"), ("출입국·외국인정책본부", "no rows matched selectors") 등.
     errors: list[tuple[str, str]] = field(default_factory=list)
 
     def extend(self, other: "ScrapeResult") -> None:
@@ -92,15 +90,20 @@ def _extract_content(soup: BeautifulSoup, selector: str) -> str:
     return body.get_text("\n", strip=True) if body else ""
 
 
-def fetch_articles(session, site: Site, *, max_rows: int = 15) -> ScrapeResult:
+# ---------------------------------------------------------------
+# 파싱 로직 (정적·JS 공용)
+# ---------------------------------------------------------------
+
+def _parse_list(
+    list_html: str,
+    site: Site,
+    max_rows: int,
+    fetch_detail: Callable[[str], Optional[str]],
+) -> ScrapeResult:
+    """List HTML을 파싱하고 keyword·window 필터를 통과한 글에 대해 fetch_detail로 본문을 가져온다."""
     result = ScrapeResult()
+    soup = BeautifulSoup(list_html, "lxml")
 
-    res = get(session, site.list_url, encoding=site.encoding)
-    if res is None:
-        result.errors.append((site.name, "목록 페이지 접속 실패 (네트워크 또는 5xx)"))
-        return result
-
-    soup = BeautifulSoup(res.text, "lxml")
     rows: list[Tag] = []
     for sel in (s.strip() for s in site.row_selector.split(",")):
         if not sel:
@@ -109,7 +112,7 @@ def fetch_articles(session, site: Site, *, max_rows: int = 15) -> ScrapeResult:
         if rows:
             break
     if not rows:
-        msg = "목록 셀렉터 매칭 실패 — 사이트 구조가 변경됐을 가능성 (config.py의 row_selector 확인)"
+        msg = "목록 셀렉터 매칭 실패 — 사이트 구조가 변경됐을 가능성"
         log.warning("[%s] %s", site.name, msg)
         result.errors.append((site.name, msg))
         return result
@@ -141,10 +144,10 @@ def fetch_articles(session, site: Site, *, max_rows: int = 15) -> ScrapeResult:
             result.unmatched_candidates.append((site.name, title, url))
             continue
 
-        detail_res = get(session, url, encoding=site.encoding)
+        detail_html = fetch_detail(url)
         content = ""
-        if detail_res is not None:
-            detail_soup = BeautifulSoup(detail_res.text, "lxml")
+        if detail_html:
+            detail_soup = BeautifulSoup(detail_html, "lxml")
             content = _extract_content(detail_soup, site.detail_content_selector)[:4000]
 
         result.articles.append(
@@ -160,13 +163,79 @@ def fetch_articles(session, site: Site, *, max_rows: int = 15) -> ScrapeResult:
     return result
 
 
+# ---------------------------------------------------------------
+# 페치 dispatch
+# ---------------------------------------------------------------
+
+def fetch_articles(session, site: Site, *, max_rows: int = 15, js_renderer=None) -> ScrapeResult:
+    """site.requires_js 면 js_renderer를 통해, 아니면 requests 세션으로 페치."""
+    if site.requires_js:
+        if js_renderer is None:
+            result = ScrapeResult()
+            result.errors.append(
+                (site.name, "JS 렌더러 미초기화 — fetch_all 경로로 호출하세요")
+            )
+            return result
+        list_html = js_renderer.fetch(site.list_url)
+        if list_html is None:
+            result = ScrapeResult()
+            result.errors.append((site.name, "JS 렌더 목록 페이지 로드 실패"))
+            return result
+        return _parse_list(list_html, site, max_rows, fetch_detail=js_renderer.fetch)
+
+    res = get(session, site.list_url, encoding=site.encoding)
+    if res is None:
+        result = ScrapeResult()
+        result.errors.append((site.name, "목록 페이지 접속 실패 (네트워크 또는 5xx)"))
+        return result
+
+    def static_detail(url: str) -> Optional[str]:
+        d = get(session, url, encoding=site.encoding)
+        return d.text if d is not None else None
+
+    return _parse_list(res.text, site, max_rows, fetch_detail=static_detail)
+
+
 def fetch_all(sites: Iterable[Site] = SITES) -> ScrapeResult:
+    """SITES 목록을 순회. requires_js 사이트가 있으면 Playwright 1회 부팅하여 공유."""
+    sites_list = list(sites)
     session = make_session()
     combined = ScrapeResult()
-    for site in sites:
+
+    needs_js = any(s.requires_js for s in sites_list)
+    js_ctx = None
+    if needs_js:
         try:
-            combined.extend(fetch_articles(session, site))
-        except Exception as exc:  # noqa: BLE001 - one site shouldn't kill the run
-            log.exception("[%s] scrape failed", site.name)
-            combined.errors.append((site.name, f"예외 발생: {type(exc).__name__}: {exc}"))
+            from .js_fetcher import JsRenderer
+            js_ctx = JsRenderer()
+            js_ctx.__enter__()
+        except ImportError as exc:
+            log.error("playwright import 실패: %s", exc)
+            for site in sites_list:
+                if site.requires_js:
+                    combined.errors.append(
+                        (site.name, "playwright 미설치 — requirements.txt 및 워크플로우 확인")
+                    )
+            sites_list = [s for s in sites_list if not s.requires_js]
+        except Exception as exc:  # noqa: BLE001
+            log.exception("playwright 초기화 실패")
+            for site in sites_list:
+                if site.requires_js:
+                    combined.errors.append(
+                        (site.name, f"JS 렌더러 초기화 실패: {type(exc).__name__}: {exc}")
+                    )
+            sites_list = [s for s in sites_list if not s.requires_js]
+
+    try:
+        for site in sites_list:
+            try:
+                renderer = js_ctx if site.requires_js else None
+                combined.extend(fetch_articles(session, site, js_renderer=renderer))
+            except Exception as exc:  # noqa: BLE001 - one site shouldn't kill the run
+                log.exception("[%s] scrape failed", site.name)
+                combined.errors.append((site.name, f"예외 발생: {type(exc).__name__}: {exc}"))
+    finally:
+        if js_ctx is not None:
+            js_ctx.__exit__(None, None, None)
+
     return combined

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml>=5.0.0
 python-dotenv>=1.0.0
 pypdf>=4.0.0
 python-docx>=1.1.0
+playwright>=1.40.0


### PR DESCRIPTION
## 목표

JS 렌더링 사이트(현재는 과학기술정보통신부) 지원을 위해 Playwright 기반 헤드리스 브라우저 페치 경로 추가. 기존 정적 사이트는 영향 없음.

## 추가 사항

### 신규 모듈 `briefing/js_fetcher.py`
- `JsRenderer` 컨텍스트 매니저 — `with` 블록 동안 브라우저 1회 부팅, 여러 URL 재사용
- Chromium headless, ko-KR locale, 기존 User-Agent 그대로
- `goto(domcontentloaded)` → `wait_for_load_state(networkidle)` → 옵션으로 `wait_selector`

### 리팩터 `briefing/scraper.py`
- `Site.requires_js: bool` 플래그 추가
- 파싱 로직(`_parse_list`)을 정적·JS 공용으로 분리
- `fetch_all()` 이 JS 사이트 발견 시 1회만 `JsRenderer` 부팅 후 모든 JS 사이트에서 재사용

### `briefing/diagnose.py` 확장
- `requires_js=True` 사이트는 Playwright로 렌더링한 후 동일한 19개 후보 셀렉터 매칭 진단
- 첫 글 상세 페이지도 JS 렌더링으로 페치

### `.github/workflows/daily-briefing.yml`
- `python -m playwright install --with-deps chromium` 단계 추가
- `~/.cache/ms-playwright` 캐싱 (requirements.txt 해시 기반) — 콜드 캐시 시 ~2분, 이후 즉시

### `briefing/config.py`
- 과기부 `Site` 항목 재추가, `requires_js=True`
- placeholder 셀렉터 — 머지 후 diagnose 결과로 정확한 값 보정 예정

## 다음 단계 (사용자 확인용)

1. **본 PR 머지**
2. **Actions → Run workflow** 클릭, `diagnose: true` 입력
3. 첫 실행은 Playwright 다운로드로 ~3분 소요됨, 이후 ~1분
4. 로그에서 `[과학기술정보통신부]` 섹션 확인 → 실제 매칭된 셀렉터 공유
5. 그걸로 `config.py` 셀렉터 보정 PR 만들어 머지

## 비용 영향

- 의존성: Chromium ~150MB (캐시됨)
- CI 실행시간: JS 사이트 1개 기준 +30초 (네트워크 idle 대기 포함)
- 메모리: Chromium 프로세스 ~200MB (러너 7GB 한도 대비 무시 가능)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_