### PR TITLE
하이코리아 외부 링크 버그 수정 + 워크플로우 입력을 체크박스로 변경

### DIFF
--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -9,12 +9,14 @@ on:
     inputs:
       dry_run:
         description: "Issue를 생성하지 않고 본문만 출력"
+        type: boolean
         required: false
-        default: "false"
+        default: false
       diagnose:
         description: "각 사이트 HTML 구조 진단 (셀렉터 보정용, 본 작업은 실행 안 함)"
+        type: boolean
         required: false
-        default: "false"
+        default: false
 
 jobs:
   run-briefing:

--- a/briefing/hikorea.py
+++ b/briefing/hikorea.py
@@ -60,6 +60,8 @@ def _extract_text(path: Path) -> str | None:
 
 def _find_attachment_links(soup: BeautifulSoup) -> list[tuple[str, str]]:
     """Returns list of (display_name, href) for file download links."""
+    from urllib.parse import urlparse
+
     candidates: list[tuple[str, str]] = []
     seen: set[str] = set()
     for a in soup.find_all("a"):
@@ -67,6 +69,16 @@ def _find_attachment_links(soup: BeautifulSoup) -> list[tuple[str, str]]:
         text = a.get_text(" ", strip=True)
         if not href or not text:
             continue
+
+        # 외부 링크 제외 (예: 페이지 본문 안에 박힌 microsoft.com 'HWP 뷰어 다운로드' 안내).
+        # netloc이 비어있으면 상대경로 (hikorea 자체) — 통과.
+        parsed = urlparse(href)
+        if parsed.netloc and "hikorea.go.kr" not in parsed.netloc.lower():
+            continue
+        # 스킴이 http/https/없음(상대경로)이 아닌 것은 제외 (예: ttp://... 오타).
+        if parsed.scheme and parsed.scheme.lower() not in ("http", "https"):
+            continue
+
         href_l = href.lower()
         is_download = (
             "download" in href_l


### PR DESCRIPTION
## 배경

Issue #10 실행 로그에서 두 가지 문제가 발견됨.

## 수정 사항

### 1. 🐛 HiKorea 외부 링크를 첨부파일로 오인하는 버그
하이코리아 본문에 박힌 외부 안내 링크(예: HWP 뷰어 다운로드 안내용 microsoft.com 링크)를 `_find_attachment_links` 가 첨부파일로 잘못 인식해 다운로드 시도 → 404로 실패하면서 로그에 에러 발생. 일부 링크엔 `ttp://...` 오타까지 있어 `requests.exceptions.InvalidSchema` 까지 발생.

**수정**: `_find_attachment_links` 에서 네 단계 필터 추가
- netloc이 비어있는 상대경로 → 통과 (하이코리아 자체)
- netloc에 `hikorea.go.kr` 포함 → 통과
- 그 외 모든 외부 호스트 → 제외
- 스킴이 http/https 가 아닌 것 (`ttp://` 등 오타) → 제외

### 2. 워크플로우 입력을 체크박스로 변경
이전 실행에서 사용자가 `diagnose` 입력에 `t` 만 입력 → bash 비교 `"t" = "true"` false → diagnose 모드가 아닌 일반 브리핑 모드로 떨어짐.

**수정**: `dry_run`, `diagnose` 입력을 `type: boolean` 으로 변경. GitHub UI가 체크박스로 렌더링하므로 텍스트 오타 불가능. bash 비교는 그대로 (`true`/`false` 리터럴 값으로 오는 건 동일).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_