### PR TITLE
JS 대기 강화 + iframe/AJAX/리다이렉트 진단 추가

### DIFF
--- a/briefing/diagnose.py
+++ b/briefing/diagnose.py
@@ -191,6 +191,45 @@ def inspect_site(session, site: Site, js_renderer=None) -> None:
         if not article_link_patterns:
             print("  (의심스러운 글-링크 패턴 없음)")
 
+        # iframe / 외부 script / body 통계 — 글 목록이 iframe·후속AJAX·딴 데서 오는지 식별
+        print("\n--- iframe / script src ---")
+        iframes = soup.find_all("iframe")
+        if iframes:
+            print(f"iframe {len(iframes)}개 발견 (글 목록이 여기 들어있을 수 있음):")
+            for ifr in iframes[:5]:
+                src = ifr.get("src", "") or ifr.get("data-src", "")
+                print(f"  <iframe src={src[:140]!r}>")
+        else:
+            print("iframe 없음")
+        ext_scripts = [s.get("src", "") for s in soup.find_all("script", src=True)]
+        ajax_hint = [s for s in ext_scripts if any(k in s.lower() for k in ("api", "json", "list", "data", "fetch", "ajax"))]
+        if ajax_hint:
+            print(f"\n글-API 의심 script src ({len(ajax_hint)}개):")
+            for s in ajax_hint[:8]:
+                print(f"  {s[:160]!r}")
+
+        # body 통계 — '데이터를 불러오는 중' 같은 placeholder 메시지 탐지
+        print("\n--- body 통계 ---")
+        body = soup.find("body")
+        if body:
+            body_text = body.get_text(" ", strip=True)
+            a_count = len(body.find_all("a"))
+            print(f"<body> 텍스트 {len(body_text)}자, <a> {a_count}개")
+            for keyword in ["데이터를 불러", "불러오는 중", "loading", "잠시만", "오류가 발생", "권한이 없", "로그인이 필요"]:
+                if keyword in body_text:
+                    idx = body_text.find(keyword)
+                    ctx = body_text[max(0, idx - 30): idx + 80]
+                    print(f"  '{keyword}' 발견: {ctx!r}")
+            # 날짜 패턴 등장 횟수 — 글 목록이 있으면 보통 10개 이상
+            date_count = len(re.findall(r"\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2}", body_text))
+            print(f"날짜 패턴(YYYY.MM.DD) 등장 횟수: {date_count}")
+
+        # 최종 URL — 리다이렉트로 다른 페이지에 갔는지 확인
+        if site.requires_js and js_renderer is not None:
+            final_url = getattr(js_renderer, "last_final_url", None)
+            if final_url and final_url != site.list_url:
+                print(f"\n⚠️ 최종 URL이 list_url과 다름: {final_url}")
+
     # 4) 본문 추출 시도 — 셀렉터 첫 후보로 첫 글의 상세페이지에 접속해 본문 컨테이너 후보 보고
     if matches:
         best_sel, _ = matches[0]

--- a/briefing/js_fetcher.py
+++ b/briefing/js_fetcher.py
@@ -29,8 +29,9 @@ Object.defineProperty(navigator, 'plugins', { get: () => [1, 2, 3, 4, 5] });
 """
 
 DEFAULT_GOTO_TIMEOUT_MS = 60_000
-NETWORK_IDLE_TIMEOUT_MS = 20_000
+NETWORK_IDLE_TIMEOUT_MS = 40_000  # 추가 AJAX가 늦게 오는 KR gov SPA 대응
 WAIT_SELECTOR_TIMEOUT_MS = 10_000
+POST_IDLE_GRACE_MS = 3_000  # networkidle 후에도 다음 XHR 한 번 더 기다림
 
 
 class JsRenderer:
@@ -83,24 +84,33 @@ class JsRenderer:
                 pass
 
     def fetch(self, url: str, *, wait_selector: Optional[str] = None) -> Optional[str]:
-        """렌더링된 페이지 HTML 반환. 실패 시 None (last_error에 사유 기록)."""
+        """렌더링된 페이지 HTML 반환. 실패 시 None (last_error에 사유 기록).
+
+        부수 효과: self.last_final_url에 최종 URL(리다이렉트 후) 기록.
+        """
         if self._context is None:
             raise RuntimeError("JsRenderer must be used as a context manager")
 
         self.last_error = None
+        self.last_final_url: Optional[str] = None
         page = self._context.new_page()
         try:
             page.goto(url, wait_until="domcontentloaded", timeout=DEFAULT_GOTO_TIMEOUT_MS)
             try:
                 page.wait_for_load_state("networkidle", timeout=NETWORK_IDLE_TIMEOUT_MS)
             except Exception:  # noqa: BLE001
-                # networkidle 도달 실패해도 일단 진행 (DOM은 이미 로드됨)
                 log.debug("networkidle timeout for %s — proceeding anyway", url)
+            # networkidle 후 한 번 더 grace — 마지막 XHR이 살짝 늦게 시작했을 때 대비
+            try:
+                page.wait_for_timeout(POST_IDLE_GRACE_MS)
+            except Exception:  # noqa: BLE001
+                pass
             if wait_selector:
                 try:
                     page.wait_for_selector(wait_selector, timeout=WAIT_SELECTOR_TIMEOUT_MS)
                 except Exception:  # noqa: BLE001
                     log.warning("wait_selector %r not found on %s", wait_selector, url)
+            self.last_final_url = page.url
             return page.content()
         except Exception as exc:  # noqa: BLE001
             err = f"{type(exc).__name__}: {exc}"


### PR DESCRIPTION
## 배경

이전 diagnose에서 과기부 페이지가 JS 렌더는 통과했지만(176KB, 정확한 title) 글 목록 자체가 DOM에 없음. top 리스트는 모두 GNB/메뉴, 글-링크 패턴 0개.

가능성 두 가지:
- (a) 글 목록이 networkidle 발생 이후에 추가 XHR로 늦게 옴 (대기 부족)
- (b) 글 목록이 iframe 내부에 있음 (우리는 부모 프레임만 봄)

본 PR로 두 케이스를 모두 식별 가능.

## 변경 사항

### `js_fetcher.py`
- `networkidle` 대기 20s → **40s**
- networkidle 후 **3초 grace** 추가 (마지막 XHR 따라잡기)
- `last_final_url` 기록 (리다이렉트 감지용)

### `diagnose.py`
- **iframe 탐지**: 모든 iframe과 src 출력 — "글 목록이 iframe 안에 있을 때"
- **AJAX 의심 script**: external script src 중 `api`/`json`/`list`/`data`/`fetch`/`ajax` 키워드 포함된 것
- **body 통계**:
  - 텍스트 길이, `<a>` 개수
  - 'loading' 메시지 패턴 검사 (`"데이터를 불러"`, `"잠시만"`, `"권한이 없"`, `"로그인이 필요"`)
  - 날짜 패턴(YYYY.MM.DD) 등장 횟수 — 글 목록이면 보통 10개 이상
- **최종 URL 비교**: list_url과 다르면 ⚠️ 경고

## 머지 후 기대 출력

```
--- iframe / script src ---
iframe N개 발견:
  <iframe src='https://www.msit.go.kr/...'>     ← (b) 케이스라면 여기 보임

--- body 통계 ---
<body> 텍스트 NNNN자, <a> NN개
  '데이터를 불러' 발견: '...데이터를 불러오는 중입니다...'   ← 로딩 메시지면 (a) 케이스
날짜 패턴(YYYY.MM.DD) 등장 횟수: N

⚠️ 최종 URL이 list_url과 다름: https://...                ← 리다이렉트 케이스
```

이 셋 중 어느 게 보이느냐로 정확한 원인 식별 가능.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_