### PR TITLE
MSIT 제외 + 고용노동부 추가 (외국인 노동 정책 강화)

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -63,9 +63,10 @@ class Site:
     requires_js: bool = False  # True면 Playwright(JsRenderer)로 페치
 
 
-# 법무부·출입국은 통합 CMS(artclLinkView/_artclTd*/_articleTable) — 정적 HTTP로 충분.
-# 과기부는 글 목록이 JS로 렌더링되는 SPA 구조 — Playwright(requires_js=True)로 처리.
-# 과기부 셀렉터는 1차 placeholder. diagnose 모드 결과를 보고 정확한 클래스로 보정 필요.
+# 법무부·출입국·고용노동부 — 모두 정부 통합 CMS(artclLinkView/_artclTd*/_articleTable) 사용.
+# MSIT (msit.go.kr)는 글 목록이 정적 HTML에 없고 Playwright+stealth 로도 데이터 fetch
+# 시도조차 안 함 (날짜 패턴 0개, AJAX 힌트 없음 — 비-한국 IP 차단 추정). 이민 정책
+# 기여도가 낮아 추적 대상에서 제외. 필요 시 한국 IP proxy 또는 RSS 피드로 재도입 가능.
 SITES: tuple[Site, ...] = (
     Site(
         name="법무부",
@@ -86,21 +87,15 @@ SITES: tuple[Site, ...] = (
         detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
     Site(
-        name="과학기술정보통신부",
-        list_url="https://www.msit.go.kr/bbs/list.do?sCode=user&mPid=208&mId=307",
-        base_url="https://www.msit.go.kr",
-        requires_js=True,  # JS 렌더링 사이트 → Playwright 사용
-        # 1차 placeholder 셀렉터 — diagnose 결과 보고 정확한 값으로 교체.
-        row_selector=(
-            "div.board_list table tbody tr, table.board_list tbody tr, "
-            "table tbody tr, ul.board_list > li, div.bbsList li"
-        ),
-        title_link_selector="td.subject a, td.title a, a.title, .subject a, td a",
-        date_selector="td.date, td.reg_date, .date, td.regdate, .regdate",
-        detail_content_selector=(
-            "div.board_view, div.view_cont, div.viewCont, div.bbs_view, "
-            ".board_view_cont, .view_content, article, div.article_cont"
-        ),
+        name="고용노동부",
+        list_url="https://www.moel.go.kr/news/enews/list.do",
+        base_url="https://www.moel.go.kr",
+        # 정부 통합 CMS 추정 — MOJ/Immigration과 동일 셀렉터로 1차 시도.
+        # 다르면 diagnose 결과로 보정.
+        row_selector="div._articleTable table tbody tr, table tbody tr",
+        title_link_selector="a.artclLinkView, td._artclTdTitle a",
+        date_selector="td._artclTdRdate",
+        detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
 )
 


### PR DESCRIPTION
## 변경 사항

추적 사이트를 **MSIT → 고용노동부**로 교체.

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| 사이트 1 | 법무부 | (동일) |
| 사이트 2 | 출입국·외국인정책본부 | (동일) |
| 사이트 3 | **과학기술정보통신부** ⚠️ | **고용노동부** |

## 사유

### MSIT 제외
지금까지의 진단 결과가 가리키는 바:
- Playwright + stealth (real Chrome UA, navigator.webdriver shim) + 40s networkidle + 3s grace 이후에도
- 렌더된 DOM에 **날짜 패턴 0회**, 글-링크 패턴 0개, AJAX 의심 script 0개, iframe 0개
- → 사이트가 **데이터 fetch 시도조차 안 하는 상태**로 응답
- 추정 원인: 비-한국 IP에 대한 anti-bot 차단

이민 정책 측면에서도 MSIT 기여도는 제한적(가끔 D-8/E-7-1 R&D 인재 정책).

### 고용노동부 추가
외국인 노동 정책의 **본진**:
- 고용허가제(E-9), 외국인근로자 사업장 변경, 직장 내 처우, 계절근로자(E-8) 정책 등
- 정부 통합 CMS 사용 추정 → MOJ/Immigration과 동일한 `artclLinkView`/`_artclTd*` 셀렉터 1차 시도
- Playwright 불필요 (정적 HTTP로 충분할 것으로 예상)

## 머지 후 검증

1. PR 머지
2. Actions → Run workflow → `dry_run: true` 체크 → 실행
3. 로그에서 `[고용노동부]` 가 정상 fetch 됐는지 확인
4. 만약 셀렉터 안 맞으면 ⚠️ 경고가 Issue 본문에 자동 표시됨 → 그때 diagnose 재실행

## 보존된 것

- Playwright 인프라 (JsRenderer, scraper의 requires_js dispatch, 워크플로우 install 단계) 그대로 유지
- 향후 다른 JS-rendered 사이트 추가 시 `requires_js=True` 만 켜면 동작

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrP7tgR7tfCa8AbnWbdHFp)_