### PR TITLE
스케줄: 09:30 → 10:00 KST 윈도우·트리거 이동

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,10 @@ ANTHROPIC_API_KEY=sk-ant-...
 # 필요 시 claude-haiku-4-5 (저비용) 또는 claude-opus-4-7 (고품질)
 CLAUDE_MODEL=claude-sonnet-4-6
 
-# 브리핑 윈도우: 매일 [어제 09:30, 오늘 09:30) KST 24시간 구간 센싱
+# 브리핑 윈도우: 매일 [어제 10:00, 오늘 10:00) KST 24시간 구간 센싱
 WINDOW_HOURS=24
-WINDOW_END_HOUR_KST=9
-WINDOW_END_MINUTE_KST=30
+WINDOW_END_HOUR_KST=10
+WINDOW_END_MINUTE_KST=0
 
 # 브리핑 Issue 자동 close: 생성된 지 N일 지난 Issue를 매 실행마다 정리
 ISSUE_KEEP_DAYS=30

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -2,9 +2,10 @@ name: Daily Immigration Policy Briefing
 
 on:
   schedule:
-    # 한국시간 매일 09:30 = UTC 00:30
-    # 윈도우: 어제 09:30 KST ~ 오늘 09:30 KST. 게시일 ≤ 당일 09:30 KST 필터 적용.
-    - cron: "30 0 * * *"
+    # 한국시간 매일 10:00 = UTC 01:00
+    # 윈도우: 어제 10:00 KST ~ 오늘 10:00 KST. 게시일 ≤ 당일 10:00 KST 필터 적용.
+    # 스크레이프·요약 완료 즉시 메일 발송 (정상 환경에서 ~10:01~10:02 KST 도착).
+    - cron: "0 1 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -65,8 +66,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
-          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '9' }}
-          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '30' }}
+          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '10' }}
+          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '0' }}
           ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # 이메일 채널: GitHub Issue 경유가 아닌 SMTP 로 직접 발송 → 수신자 입장에서 GitHub 흔적 0.
           # 레거시 운영과 동일한 secret 명 재사용 (EMAIL_SENDER/EMAIL_PASSWORD/EMAIL_RECEIVER).

--- a/briefing/config.py
+++ b/briefing/config.py
@@ -29,12 +29,12 @@ KEYWORDS: tuple[str, ...] = (
     "E-7", "F-2", "F-4", "F-5", "F-6", "D-8", "D-10",
 )
 
-# 브리핑 윈도우: 매일 [어제 09:30 KST, 오늘 09:30 KST] 24시간 구간을 센싱.
-# 워크플로우는 매일 09:30 KST (UTC 00:30, cron "30 0 * * *")에 실행되며,
-# 게시일 ≤ 당일 09:30 KST 조건을 만족하는 글만 수집한다.
+# 브리핑 윈도우: 매일 [어제 10:00 KST, 오늘 10:00 KST] 24시간 구간을 센싱.
+# 워크플로우는 매일 10:00 KST (UTC 01:00, cron "0 1 * * *")에 실행되며,
+# 게시일 ≤ 당일 10:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
 WINDOW_HOURS = int(os.getenv("WINDOW_HOURS", "24"))
-WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "9"))
-WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "30"))
+WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "10"))
+WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "0"))
 
 
 def compute_window(now: datetime | None = None) -> tuple[datetime, datetime]:


### PR DESCRIPTION
## Summary

수신자 요청: 매일 아침 **10:00 KST 까지 업데이트된 내용을 반영하여 확인되자마자 발송**.

- **cron**: `30 0 * * *` (09:30 KST) → `0 1 * * *` (**10:00 KST**, UTC 01:00)
- **윈도우 종료 시각**: 09:30 → **10:00 KST**. 24시간 윈도우 유지 → `[어제 10:00, 오늘 10:00)`.
- 환경변수 기본값 (`WINDOW_END_HOUR_KST=10`, `WINDOW_END_MINUTE_KST=0`) 도 동기화.
- 워크플로우 시작 후 스크레이프·요약 완료 즉시 발송 → 정상 환경에서 **~10:01~10:02 KST** 도착.

## Test plan
- [x] 로컬 diff (`config.py` / workflow / `.env.example` 3 파일, +14/-13)
- [ ] 머지 후 내일 (2026-05-15) 10:00 KST 정기 cron 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)