### PR TITLE
섹션 헤더에 사이트 list URL 하이퍼링크 추가

### DIFF
--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -27,6 +27,18 @@ def _site_order() -> list[str]:
     return [s.name for s in SITES]
 
 
+def _site_list_urls() -> dict[str, str]:
+    return {s.name: s.list_url for s in SITES}
+
+
+def _site_header(name: str, url: str | None) -> str:
+    """### 섹션 헤더 — 사이트 목록 URL 이 있으면 markdown 링크로 감싼다.
+    상세 article URL과 달리 list URL 은 게시판 첫 페이지라 기업 메일 보안 게이트
+    웨이의 평판 검사에 잘 걸리지 않음. 사용자가 직접 클릭해 "정말 관련 글이 없는지"
+    크로스체크 가능."""
+    return f"### [{name}]({url})" if url else f"### {name}"
+
+
 def render_markdown(
     *,
     articles: list[ArticleBriefing],
@@ -38,6 +50,7 @@ def render_markdown(
     title = f"[일일 브리핑] 이민·비자 정책 동향 ({today})"
 
     site_order = _site_order()
+    site_urls = _site_list_urls()
     # 출처 표기는 도메인명만(서비스명) — 본문 어디서도 표시 텍스트와 href가
     # 어긋난 anchor (기업 메일 필터의 피싱 휴리스틱 트리거)를 만들지 않는다.
     sources_line = " · ".join(site_order)
@@ -65,7 +78,7 @@ def render_markdown(
     # 클릭 가능하게 렌더하는 경우가 많지만, 보안 gateway 가 본문 링크를 차단해도
     # 텍스트로는 그대로 보이므로 복사 경로는 항상 유효.
     for name in site_order:
-        lines.append(f"### {name}")
+        lines.append(_site_header(name, site_urls.get(name)))
         lines.append("")
         site_articles = articles_by_site.get(name, [])
         if site_articles:
@@ -92,7 +105,13 @@ def render_markdown(
     all_new_titles = all_new_titles or {}
     for name in site_order:
         entries = all_new_titles.get(name, [])
-        lines.append(f"### {name} ({len(entries)}건)")
+        # 섹션 헤더에 사이트 list URL 하이퍼링크 + 건수 표기.
+        url = site_urls.get(name)
+        header_label = f"{name} ({len(entries)}건)"
+        if url:
+            lines.append(f"### [{header_label}]({url})")
+        else:
+            lines.append(f"### {header_label}")
         lines.append("")
         if entries:
             for idx, (t, u) in enumerate(entries, start=1):


### PR DESCRIPTION
## Summary

수신자가 매칭 글이 없을 때도 "정말 관련 글이 없는지" 검증할 수 있게, **오늘의 핵심** / **그날 올라온 새 글 전체** 두 섹션의 사이트별 헤더(`### 법무부` 등)를 해당 게시판 list URL 로 하이퍼링크화.

- 기존: `### 법무부`
- 신규: `### [법무부](https://www.moj.go.kr/moj/221/subview.do)`
- 새 글 전체에서는 건수까지 포함: `### [법무부 (N건)](URL)`
- 본문 내 개별 article URL 은 그대로 plain text 라인 (복사·붙여넣기 흐름 보존)

## 평판 검사 리스크
사이트 list URL 은 표준 게시판 첫 페이지(`.do` + 짧은 query string)라 article deep link 보다 보안 게이트웨이 통과 가능성이 높음. 통과 안 되면 list URL 도 plain text 로 되돌리는 fallback 즉시 가능.

## Test plan
- [x] 로컬 diff 검증 (1 파일, +21/-2)
- [ ] 머지 후 4명 수신자에게 샘플 발송 — 사이트 헤더 클릭 가능 여부 + 메일 게이트웨이 통과 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)