### PR TITLE
사이트 라벨 명확화 + 체류관리지침 페이지 갱신 추적

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -89,7 +89,7 @@ class Site:
 # 셀렉터는 사이트 진단 결과(diagnose) 기반으로 보정 가능.
 SITES: tuple[Site, ...] = (
     Site(
-        name="법무부",
+        name="법무부 보도자료",
         list_url="https://www.moj.go.kr/moj/221/subview.do",
         base_url="https://www.moj.go.kr",
         row_selector="div._articleTable table tbody tr, table tbody tr",
@@ -98,7 +98,7 @@ SITES: tuple[Site, ...] = (
         detail_content_selector="div.artclView, div._articleTable._mojView",
     ),
     Site(
-        name="출입국·외국인정책본부",
+        name="출입국·외국인정책본부 보도자료",
         list_url="https://www.immigration.go.kr/immigration/1502/subview.do",
         base_url="https://www.immigration.go.kr",
         row_selector="div._articleTable table tbody tr, table tbody tr",
@@ -114,7 +114,7 @@ SITES: tuple[Site, ...] = (
     # 한 줄만 살리면 즉시 부활할 수 있도록 보존. 활성화하려면 _MSIT_SITE 를
     # SITES 안으로 옮기면 된다.
     Site(
-        name="하이코리아",
+        name="하이코리아 공지사항",
         list_url="https://www.hikorea.go.kr/board/BoardNtcListR.pt?BBS_GB_CD=BS10",
         base_url="https://www.hikorea.go.kr",
         # 하이코리아 공지사항 — 자체 시스템. diagnose 결과 기반 셀렉터.
@@ -160,6 +160,32 @@ _MSIT_SITE = Site(
     # 빈 상태에서 채워지는 시점을 기준.
     wait_selector="div.board_list p.title:not(:empty)",
     requires_js=True,
+)
+
+
+@dataclass(frozen=True)
+class TrackedPage:
+    """게시판 목록이 아니라 '단일 글 페이지'의 첨부파일 갱신만 추적.
+
+    예: 하이코리아 체류관리지침처럼 글 URL은 고정인데 첨부 PDF/HWP 가
+    교체되는 페이지. 페이지의 apndList hidden field 또는 첨부 링크
+    영역을 해시해 비교한다."""
+
+    label: str
+    url: str
+    # 변경 신호 추출 규칙. 기본은 apndList hidden field (하이코리아 게시판 패턴).
+    # 다른 사이트면 별도 추출 regex 를 줘서 재사용 가능.
+    signal_pattern: str = r'name="apndList"[^>]*value="([^"]*)"'
+
+
+TRACKED_PAGES: tuple[TrackedPage, ...] = (
+    TrackedPage(
+        label="체류관리지침 (체류자격별 통합 안내 매뉴얼)",
+        url=(
+            "https://www.hikorea.go.kr/board/BoardNtcDetailR.pt?"
+            "BBS_SEQ=1&BBS_GB_CD=BS10&NTCCTT_SEQ=1062&page=1"
+        ),
+    ),
 )
 
 

--- a/briefing/main.py
+++ b/briefing/main.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from . import cleanup, emailer, publisher, scraper, storage, summarizer  # noqa: E402
+from . import cleanup, emailer, publisher, scraper, storage, summarizer, tracked_pages  # noqa: E402
 from .config import SITES, ensure_dirs  # noqa: E402
 
 logging.basicConfig(
@@ -43,6 +43,7 @@ def run(*, dry_run: bool = False) -> int:
         all_new_titles.setdefault(site, []).append((title, url))
 
     log.info("Step 2/3: classifying & summarizing immigration-relevant articles")
+    tracked_changes: list[tracked_pages.TrackedPageChange] = []
     with storage.connect() as conn:
         for art in scrape_result.articles:
             key = (art.site, art.url)
@@ -65,10 +66,15 @@ def run(*, dry_run: bool = False) -> int:
                 )
             )
 
+        # 추적 페이지(단일 글 갱신) 검사 — 같은 connection 안에서 수행해 트랜잭션 일관성.
+        tracked_changes = tracked_pages.check_all(conn)
+        log.info("  tracked-page changes detected: %d", len(tracked_changes))
+
     title, body = publisher.render_markdown(
         articles=article_briefings,
         all_new_titles=all_new_titles,
         scrape_errors=scrape_result.errors,
+        tracked_changes=tracked_changes,
     )
 
     if dry_run:
@@ -113,6 +119,7 @@ def run(*, dry_run: bool = False) -> int:
             articles=article_briefings,
             all_new_titles=all_new_titles,
             scrape_errors=scrape_result.errors,
+            tracked_changes=tracked_changes,
         )
         delivered_any = delivered_any or issue_ok
 

--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -44,6 +44,7 @@ def render_markdown(
     articles: list[ArticleBriefing],
     all_new_titles: dict[str, list[tuple[str, str]]] | None = None,
     scrape_errors: list[tuple[str, str]] | None = None,
+    tracked_changes: list | None = None,
 ) -> tuple[str, str]:
     now = datetime.now(KST)
     today = now.strftime("%Y-%m-%d")
@@ -122,6 +123,24 @@ def render_markdown(
             lines.append("_새 글 없음_")
         lines.append("")
 
+    # 추적 페이지(고정 URL 단일 글) 의 첨부파일 갱신 알림.
+    if tracked_changes:
+        lines.append("---")
+        lines.append("")
+        lines.append("## 🔔 추적 페이지 갱신")
+        lines.append("")
+        for tc in tracked_changes:
+            tag = "🆕 첫 추적" if tc.is_first else "✏️ 변경 감지"
+            lines.append(f"### {tag} · [{tc.label}]({tc.url})")
+            lines.append("")
+            if tc.attachments:
+                lines.append("> 첨부 파일:")
+                for fname in tc.attachments:
+                    lines.append(f"> - {fname}")
+            else:
+                lines.append("> (첨부 파일 메타 추출 실패 — 페이지 직접 확인 권장)")
+            lines.append("")
+
     if scrape_errors:
         lines.append("---")
         lines.append("")
@@ -139,6 +158,7 @@ def publish(
     articles: list[ArticleBriefing],
     all_new_titles: dict[str, list[tuple[str, str]]] | None = None,
     scrape_errors: list[tuple[str, str]] | None = None,
+    tracked_changes: list | None = None,
 ) -> bool:
     repo = os.getenv("GITHUB_REPOSITORY")
     token = os.getenv("GITHUB_TOKEN")
@@ -154,6 +174,7 @@ def publish(
         articles=articles,
         all_new_titles=all_new_titles,
         scrape_errors=scrape_errors,
+        tracked_changes=tracked_changes,
     )
 
     url = f"{GITHUB_API}/repos/{repo}/issues"

--- a/briefing/storage.py
+++ b/briefing/storage.py
@@ -15,6 +15,12 @@ CREATE TABLE IF NOT EXISTS seen_articles (
     first_seen TEXT NOT NULL,
     PRIMARY KEY (site, url)
 );
+
+CREATE TABLE IF NOT EXISTS tracked_pages (
+    label TEXT PRIMARY KEY,
+    content_hash TEXT NOT NULL,
+    last_checked TEXT NOT NULL
+);
 """
 
 
@@ -43,4 +49,27 @@ def mark_article_seen(conn: sqlite3.Connection, site: str, url: str, title: str)
     conn.execute(
         "INSERT OR IGNORE INTO seen_articles(site, url, title, first_seen) VALUES (?, ?, ?, ?)",
         (site, url, title, datetime.now(KST).isoformat()),
+    )
+
+
+def get_tracked_page_hash(conn: sqlite3.Connection, label: str) -> str | None:
+    row = conn.execute(
+        "SELECT content_hash FROM tracked_pages WHERE label = ?",
+        (label,),
+    ).fetchone()
+    return row["content_hash"] if row else None
+
+
+def upsert_tracked_page_hash(
+    conn: sqlite3.Connection, label: str, content_hash: str
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO tracked_pages(label, content_hash, last_checked)
+        VALUES (?, ?, ?)
+        ON CONFLICT(label) DO UPDATE SET
+            content_hash = excluded.content_hash,
+            last_checked = excluded.last_checked
+        """,
+        (label, content_hash, datetime.now(KST).isoformat()),
     )

--- a/briefing/tracked_pages.py
+++ b/briefing/tracked_pages.py
@@ -1,0 +1,95 @@
+"""단일 글 페이지의 콘텐츠 갱신을 추적.
+
+게시판 목록과 달리 URL 이 고정인 '특정 게시글' 의 첨부 갱신을 감지한다.
+예: 하이코리아 '체류자격별 통합 안내 매뉴얼' (NTCCTT_SEQ=1062) —
+PDF/HWP 가 정기적으로 새 버전으로 교체됨.
+
+방식:
+1. 페이지 fetch
+2. signal_pattern 에 매칭되는 영역(기본: apndList hidden field) 추출
+3. SHA256 해시
+4. DB 의 직전 해시와 비교
+5. 다르면 변경 알림 + 새 해시 저장
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import sqlite3
+from dataclasses import dataclass
+
+from .config import TRACKED_PAGES, TrackedPage
+from .http_client import get, make_session
+from .storage import get_tracked_page_hash, upsert_tracked_page_hash
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class TrackedPageChange:
+    label: str
+    url: str
+    is_first: bool
+    attachments: list[str]
+
+
+# apndList 안의 ORI_FILE_NM=... 값을 뽑아내 사람 보기 좋은 첨부파일 이름 목록 생성.
+_ORI_FILE_NM_RE = re.compile(r"ORI_FILE_NM=([^,}]+)")
+
+
+def _extract_signal(html: str, pattern: str) -> str | None:
+    """signal_pattern 에 매칭되는 첫 그룹 반환. 매칭 실패 시 None."""
+    m = re.search(pattern, html)
+    return m.group(1) if m else None
+
+
+def _extract_attachment_names(signal: str) -> list[str]:
+    """apndList 형식 신호에서 ORI_FILE_NM 값을 모두 추출."""
+    return [name.strip() for name in _ORI_FILE_NM_RE.findall(signal)]
+
+
+def _check_one(
+    session, conn: sqlite3.Connection, page: TrackedPage
+) -> TrackedPageChange | None:
+    res = get(session, page.url)
+    if res is None:
+        log.warning("[tracked:%s] fetch 실패", page.label)
+        return None
+
+    signal = _extract_signal(res.text, page.signal_pattern)
+    if signal is None:
+        log.warning(
+            "[tracked:%s] signal_pattern 매칭 실패 — 페이지 구조 변경 가능성",
+            page.label,
+        )
+        # signal 없으면 변경 비교 자체가 불안정 — 알림 건너뜀.
+        return None
+
+    new_hash = hashlib.sha256(signal.encode("utf-8")).hexdigest()
+    old_hash = get_tracked_page_hash(conn, page.label)
+
+    if old_hash == new_hash:
+        return None  # 변경 없음
+
+    upsert_tracked_page_hash(conn, page.label, new_hash)
+
+    return TrackedPageChange(
+        label=page.label,
+        url=page.url,
+        is_first=old_hash is None,
+        attachments=_extract_attachment_names(signal),
+    )
+
+
+def check_all(conn: sqlite3.Connection) -> list[TrackedPageChange]:
+    session = make_session()
+    changes: list[TrackedPageChange] = []
+    for page in TRACKED_PAGES:
+        try:
+            change = _check_one(session, conn, page)
+            if change is not None:
+                changes.append(change)
+        except Exception:  # noqa: BLE001 - 한 페이지 실패가 전체를 막지 않게
+            log.exception("[tracked:%s] 점검 중 예외", page.label)
+    return changes


### PR DESCRIPTION
## Summary

### 1) 사이트 라벨 명확화
메일 섹션 헤더가 정확히 무엇을 가리키는지 명시:
- `법무부` → **법무부 보도자료**
- `출입국·외국인정책본부` → **출입국·외국인정책본부 보도자료**
- `하이코리아` → **하이코리아 공지사항** (하이코리아는 자체 보도자료 페이지가 없고 immigration.go.kr 로 위임함 — 공지사항이 자체 발행 채널)

URL/셀렉터/수집 로직은 그대로. 라벨만 변경.

### 2) 추적 페이지 (TrackedPage) 기능 신설
게시판 목록이 아니라 **고정 URL 단일 글의 첨부파일 갱신**을 감지하는 별도 채널:

- 첫 대상: 하이코리아 **체류자격별 통합 안내 매뉴얼** (NTCCTT_SEQ=1062)
- 변경 신호: 페이지 내 `apndList` hidden field (ORI_FILE_NM · APND_SEQ · 업로드 타임스탬프 모두 포함)
- 비교: SHA256(signal) vs DB 의 직전 해시
- 변경 시 메일에 "🔔 추적 페이지 갱신" 섹션 표기 + 첨부파일명 목록 노출

### 변경 파일
- `briefing/config.py` — SITES name 변경 + `TrackedPage` dataclass + `TRACKED_PAGES` 추가
- `briefing/storage.py` — `tracked_pages` 테이블 + `get_tracked_page_hash` / `upsert_tracked_page_hash`
- `briefing/tracked_pages.py` — **새 모듈** (fetch · signal 추출 · 해시 비교)
- `briefing/main.py` — `tracked_pages.check_all` 호출 + publisher 에 전달
- `briefing/publisher.py` — "🔔 추적 페이지 갱신" 섹션 렌더링

### Test plan
- [x] 로컬 diff 검증 (5 파일, +182/-4)
- [ ] 머지 후 4명 수신자에게 샘플 발송 — 새 라벨 + 체류관리지침 첫 추적("🆕 첫 추적") 알림 확인
- [ ] 다음 정기 cron (내일 10:00 KST)에서 hash 일치(변경 알림 없음) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)