### PR TITLE
추적 페이지 섹션/항목 라벨 정확화

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -180,7 +180,8 @@ class TrackedPage:
 
 TRACKED_PAGES: tuple[TrackedPage, ...] = (
     TrackedPage(
-        label="체류관리지침 (체류자격별 통합 안내 매뉴얼)",
+        # 하이코리아 게시글의 실제 제목과 동일하게 표기.
+        label="체류자격별 통합 안내 매뉴얼(최신)",
         url=(
             "https://www.hikorea.go.kr/board/BoardNtcDetailR.pt?"
             "BBS_SEQ=1&BBS_GB_CD=BS10&NTCCTT_SEQ=1062&page=1"

--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -124,10 +124,11 @@ def render_markdown(
         lines.append("")
 
     # 추적 페이지(고정 URL 단일 글) 의 첨부파일 갱신 알림.
+    # 현재 추적 대상이 모두 하이코리아 공지사항 게시판 글이라 섹션명도 이에 맞춤.
     if tracked_changes:
         lines.append("---")
         lines.append("")
-        lines.append("## 🔔 추적 페이지 갱신")
+        lines.append("## 🔔 하이코리아 공지사항")
         lines.append("")
         for tc in tracked_changes:
             tag = "🆕 첫 추적" if tc.is_first else "✏️ 변경 감지"


### PR DESCRIPTION
## Summary

- 섹션 헤더: \"🔔 추적 페이지 갱신\" → **\"🔔 하이코리아 공지사항\"**
- TrackedPage label: \"체류관리지침 (체류자격별 통합 안내 매뉴얼)\" → **\"체류자격별 통합 안내 매뉴얼(최신)\"** (하이코리아 게시글 실제 제목과 동일)

## 부수효과

`tracked_pages` 테이블의 PK가 label 이라, 라벨 변경 후 첫 발송 1회에 한해 \"🆕 첫 추적\" 알림이 다시 표시됩니다. 마이그레이션 없이 그대로 진행 — 다음 날부터 hash 일치 시 조용해짐.

## Test plan
- [x] 로컬 diff (2 파일, +4/-2)
- [ ] 머지 후 4명 수신자에게 샘플 발송 — 새 섹션명/항목명 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)