### PR TITLE
하이코리아 공지사항 복원 + 🔔 '사증 및 체류' 명명

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -83,12 +83,13 @@ class Site:
     wait_selector: str | None = None
 
 
-# 신규 보도자료 수집 소스 — 정부 통합 CMS 2곳.
-#   - 법무부 보도자료      : moj.go.kr/moj/221
-#   - 하이코리아 보도자료   : immigration.go.kr/immigration/1502
-#                            (하이코리아 메뉴의 '보도자료' 가 이 URL 로 외부 링크)
-#     공통 셀렉터: artclLinkView / _artclTd* / _articleTable
-# 하이코리아 공지사항(체류관리지침 단일 글)은 SITES 가 아니라 TRACKED_PAGES 에서 추적.
+# 신규 보도자료/공지 수집 소스 3곳:
+#   1) 법무부 보도자료                       : moj.go.kr/moj/221      (정부 통합 CMS)
+#   2) 출입국외국인정책본부/하이코리아 보도자료 : immigration.go.kr/.../1502 (정부 통합 CMS)
+#   3) 하이코리아 공지사항                    : hikorea.go.kr/.../BoardNtcListR.pt (자체 게시판)
+# (1)(2) 공통 셀렉터: artclLinkView / _artclTd* / _articleTable
+# (3) 별도 셀렉터: tr.board_line + onclick="boardDetailR('NNN')" → view URL 직접 구성.
+# TRACKED_PAGES 의 '체류자격별 통합 안내 매뉴얼(최신)' 단일 글 추적은 별도 채널(🔔 섹션).
 # 셀렉터는 사이트 진단 결과(`python -m briefing.diagnose`) 기반으로 보정 가능.
 SITES: tuple[Site, ...] = (
     Site(
@@ -110,6 +111,24 @@ SITES: tuple[Site, ...] = (
         title_link_selector="a.artclLinkView, td._artclTdTitle a",
         date_selector="td._artclTdRdate",
         detail_content_selector="div.artclView, div._articleTable._mojView",
+    ),
+    Site(
+        name="하이코리아 공지사항",
+        list_url="https://www.hikorea.go.kr/board/BoardNtcListR.pt?BBS_GB_CD=BS10",
+        base_url="https://www.hikorea.go.kr",
+        # 행: <tr class="board_line"> (검색 폼 테이블 제외용 클래스).
+        # 링크: javascript:void(0) + onclick="boardDetailR('NNN')" 패턴
+        #       → onclick_id_pattern + view_url_template 으로 view URL 직접 구성.
+        # 날짜: 마지막 td (YYYY-MM-DD 텍스트).
+        row_selector="tr.board_line",
+        title_link_selector="td a[onclick*='boardDetailR']",
+        date_selector="td:last-child",
+        detail_content_selector="div.board_view, div.viewbox, div.contents",
+        onclick_id_pattern=r"boardDetailR\('?(\d+)'?\)",
+        view_url_template=(
+            "https://www.hikorea.go.kr/board/BoardNtcDetailR.pt?"
+            "BBS_SEQ=1&BBS_GB_CD=BS10&NTCCTT_SEQ={id}&page=1"
+        ),
     ),
 )
 

--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -125,11 +125,12 @@ def render_markdown(
 
     # 추적 페이지(고정 URL 단일 글). 변경 유무와 무관하게 매일 섹션 표시 —
     # 수신자가 페이지 존재·접근성을 매일 확인할 수 있도록.
-    # 현재 추적 대상이 모두 하이코리아 공지사항 게시판 글이라 섹션명도 이에 맞춤.
+    # SITES 의 '하이코리아 공지사항' (게시판 목록) 과 라벨 충돌을 피하기 위해
+    # 단일 글 추적 섹션은 콘텐츠 성격으로 명명: '사증 및 체류'.
     if TRACKED_PAGES:
         lines.append("---")
         lines.append("")
-        lines.append("## 🔔 하이코리아 공지사항")
+        lines.append("## 🔔 사증 및 체류")
         lines.append("")
         changes_by_label = {tc.label: tc for tc in (tracked_changes or [])}
         for page in TRACKED_PAGES:


### PR DESCRIPTION
(1) SITES에 '하이코리아 공지사항' 복원 (위치: 출입국외국인정책본부/하이코리아 보도자료 다음). (2) 🔔 섹션 제목 '하이코리아 공지사항' → '사증 및 체류'. 라벨 충돌 콘텐츠 명명으로 해소.