### PR TITLE
브리핑 윈도우/스케줄: 10시 → 9시 KST

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 # 필요 시 claude-haiku-4-5 (저비용) 또는 claude-opus-4-7 (고품질)
 CLAUDE_MODEL=claude-sonnet-4-6
 
-# 브리핑 윈도우: 매일 [어제 10:00, 오늘 10:00) KST 24시간 구간 센싱
+# 브리핑 윈도우: 매일 [어제 09:00, 오늘 09:00) KST 24시간 구간 센싱
 WINDOW_HOURS=24
-WINDOW_END_HOUR_KST=10
+WINDOW_END_HOUR_KST=9
 WINDOW_END_MINUTE_KST=0
 
 # 브리핑 Issue 자동 close: 생성된 지 N일 지난 Issue를 매 실행마다 정리

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -2,10 +2,11 @@ name: Daily Immigration Policy Briefing
 
 on:
   schedule:
-    # 한국시간 매일 10:00 = UTC 01:00
-    # 윈도우: 어제 10:00 KST ~ 오늘 10:00 KST. 게시일 ≤ 당일 10:00 KST 필터 적용.
-    # 스크레이프·요약 완료 즉시 메일 발송 (정상 환경에서 ~10:01~10:02 KST 도착).
-    - cron: "0 1 * * *"
+    # 한국시간 매일 09:00 = UTC 00:00
+    # 윈도우: 어제 09:00 KST ~ 오늘 09:00 KST. 게시일 ≤ 당일 09:00 KST 필터 적용.
+    # 스크레이프·요약 완료 즉시 메일 발송 (정상 환경에서 ~09:01~09:02 KST 도착).
+    # 단, GitHub Actions 무료 cron 은 평균 ~3시간 지연되므로 실제론 KST 12시 무렵 도착할 수 있음.
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -66,7 +67,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
-          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '10' }}
+          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '9' }}
           WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '0' }}
           ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # 이메일 채널: GitHub Issue 경유가 아닌 SMTP 로 직접 발송 → 수신자 입장에서 GitHub 흔적 0.

--- a/briefing/config.py
+++ b/briefing/config.py
@@ -29,11 +29,11 @@ KEYWORDS: tuple[str, ...] = (
     "E-7", "F-2", "F-4", "F-5", "F-6", "D-8", "D-10",
 )
 
-# 브리핑 윈도우: 매일 [어제 10:00 KST, 오늘 10:00 KST] 24시간 구간을 센싱.
-# 워크플로우는 매일 10:00 KST (UTC 01:00, cron "0 1 * * *")에 실행되며,
-# 게시일 ≤ 당일 10:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
+# 브리핑 윈도우: 매일 [어제 09:00 KST, 오늘 09:00 KST] 24시간 구간을 센싱.
+# 워크플로우는 매일 09:00 KST (UTC 00:00, cron "0 0 * * *")에 실행되며,
+# 게시일 ≤ 당일 09:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
 WINDOW_HOURS = int(os.getenv("WINDOW_HOURS", "24"))
-WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "10"))
+WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "9"))
 WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "0"))
 
 


### PR DESCRIPTION
## 요약
- 일일 브리핑 윈도우 종료 시각을 KST 10:00 → 09:00 으로 1시간 앞당김
- cron `0 1 * * *` (UTC 01:00) → `0 0 * * *` (UTC 00:00) 로 트리거 시각도 09:00 KST 로 이동
- 9시까지 수집된 글을 최대한 빠르게 발송하는 것이 목표

## 변경 파일
- `.github/workflows/daily-briefing.yml` — cron, WINDOW_END_HOUR_KST 기본값, 주석
- `briefing/config.py` — WINDOW_END_HOUR_KST 기본값, 윈도우 설명 주석
- `.env.example` — 윈도우 설명 + 기본값

## 참고
- GitHub Actions 무료 cron 은 평균 ~3시간 지연되므로 실제 도착은 KST 12시 무렵일 수 있음 (정시 도착이 필요하면 외부 트리거 필요).
- repo 변수 `WINDOW_END_HOUR_KST` 가 설정돼 있지 않아 기본값 변경이 즉시 반영됨.

## 테스트
- [ ] PR 머지 후 workflow_dispatch 로 1회 수동 실행 → 로그에서 window end 가 09:00 KST 인지 확인