### PR TITLE
윈도우 07시 + cron 22UTC: 도착시각 KST 10시 무렵

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ ANTHROPIC_API_KEY=sk-ant-...
 # 필요 시 claude-haiku-4-5 (저비용) 또는 claude-opus-4-7 (고품질)
 CLAUDE_MODEL=claude-sonnet-4-6
 
-# 브리핑 윈도우: 매일 [어제 09:00, 오늘 09:00) KST 24시간 구간 센싱
+# 브리핑 윈도우: 매일 [어제 07:00, 오늘 07:00) KST 24시간 구간 센싱
 WINDOW_HOURS=24
-WINDOW_END_HOUR_KST=9
+WINDOW_END_HOUR_KST=7
 WINDOW_END_MINUTE_KST=0
 
 # 브리핑 Issue 자동 close: 생성된 지 N일 지난 Issue를 매 실행마다 정리

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -2,11 +2,11 @@ name: Daily Immigration Policy Briefing
 
 on:
   schedule:
-    # 한국시간 매일 09:00 = UTC 00:00
-    # 윈도우: 어제 09:00 KST ~ 오늘 09:00 KST. 게시일 ≤ 당일 09:00 KST 필터 적용.
-    # 스크레이프·요약 완료 즉시 메일 발송 (정상 환경에서 ~09:01~09:02 KST 도착).
-    # 단, GitHub Actions 무료 cron 은 평균 ~3시간 지연되므로 실제론 KST 12시 무렵 도착할 수 있음.
-    - cron: "0 0 * * *"
+    # 윈도우 종료는 KST 07:00 — 발송 시각을 KST 10시 무렵에 맞추기 위한 트리거 앞당김.
+    # GitHub Actions 무료 cron 은 평균 ~3시간 24분 지연되므로,
+    # cron 트리거 KST 07:00 (UTC 22:00 전일) → 실제 실행 ~KST 10:24 → 발송 ~KST 10:30 ± 30분.
+    # 윈도우: [어제 07:00 KST, 오늘 07:00 KST). 게시일 ≤ 당일 07:00 KST 필터.
+    - cron: "0 22 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -67,7 +67,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
-          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '9' }}
+          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '7' }}
           WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '0' }}
           ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # 이메일 채널: GitHub Issue 경유가 아닌 SMTP 로 직접 발송 → 수신자 입장에서 GitHub 흔적 0.

--- a/briefing/config.py
+++ b/briefing/config.py
@@ -29,11 +29,12 @@ KEYWORDS: tuple[str, ...] = (
     "E-7", "F-2", "F-4", "F-5", "F-6", "D-8", "D-10",
 )
 
-# 브리핑 윈도우: 매일 [어제 09:00 KST, 오늘 09:00 KST] 24시간 구간을 센싱.
-# 워크플로우는 매일 09:00 KST (UTC 00:00, cron "0 0 * * *")에 실행되며,
-# 게시일 ≤ 당일 09:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
+# 브리핑 윈도우: 매일 [어제 07:00 KST, 오늘 07:00 KST] 24시간 구간을 센싱.
+# 워크플로우는 매일 07:00 KST (UTC 22:00 전일, cron "0 22 * * *")에 트리거되며,
+# GitHub Actions 무료 cron 의 ~3시간 지연을 활용해 KST 10시 무렵 발송 도착을 목표.
+# 게시일 ≤ 당일 07:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
 WINDOW_HOURS = int(os.getenv("WINDOW_HOURS", "24"))
-WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "9"))
+WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "7"))
 WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "0"))
 
 


### PR DESCRIPTION
## 요약
- 윈도우 종료 시각: KST 09:00 → **07:00**
- cron 트리거: `0 0 * * *` (UTC 00:00) → `0 22 * * *` (UTC 22:00 = KST 07:00)
- 목적: GitHub Actions 무료 cron 의 평균 ~3시간 24분 지연을 활용해 **KST 10시 무렵 도착** (±30분)

## 변경 파일
- `.github/workflows/daily-briefing.yml` — cron, WINDOW_END_HOUR_KST 기본값, 주석
- `briefing/config.py` — WINDOW_END_HOUR_KST 기본값, 윈도우 설명 주석
- `.env.example` — 윈도우 설명 + 기본값

## 예상 도착 시각 (과거 30회 스케줄 실행 분포 기반)
| | 시각 |
|---|---|
| 최선 | KST 10:00 |
| 평균 | KST 10:24 ~ 10:34 |
| 최악 | KST 10:57 ~ 11:00 |

## 트레이드오프
- 윈도우가 07시로 빨라져서 **KST 07~10시 사이에 게시된 글은 다음 날 발송**됨. 정부 사이트는 보통 09~18시 게시이므로 실무적으로 큰 손실 없음.
- 정확히 정시 도착이 필요하면 외부 cron(Cloudflare Workers 등) 으로 직접 `workflow_dispatch` 호출이 더 안정적.

## 테스트
- [ ] 머지 후 다음 스케줄 실행 시각 확인 — KST 10시 무렵 도착하는지