### PR TITLE
브리핑 윈도우: 07:00 → 08:30 KST 종료

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,10 @@ ANTHROPIC_API_KEY=sk-ant-...
 # 필요 시 claude-haiku-4-5 (저비용) 또는 claude-opus-4-7 (고품질)
 CLAUDE_MODEL=claude-sonnet-4-6
 
-# 브리핑 윈도우: 매일 [어제 07:00, 오늘 07:00) KST 24시간 구간 센싱
+# 브리핑 윈도우: 매일 [어제 08:30, 오늘 08:30) KST 24시간 구간 센싱
 WINDOW_HOURS=24
-WINDOW_END_HOUR_KST=7
-WINDOW_END_MINUTE_KST=0
+WINDOW_END_HOUR_KST=8
+WINDOW_END_MINUTE_KST=30
 
 # 브리핑 Issue 자동 close: 생성된 지 N일 지난 Issue를 매 실행마다 정리
 ISSUE_KEEP_DAYS=30

--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -2,11 +2,14 @@ name: Daily Immigration Policy Briefing
 
 on:
   schedule:
-    # 윈도우 종료는 KST 07:00 — 발송 시각을 KST 10시 무렵에 맞추기 위한 트리거 앞당김.
+    # 윈도우 종료는 KST 08:30 — 트리거 시각을 윈도우 종료에 맞춤.
     # GitHub Actions 무료 cron 은 평균 ~3시간 24분 지연되므로,
-    # cron 트리거 KST 07:00 (UTC 22:00 전일) → 실제 실행 ~KST 10:24 → 발송 ~KST 10:30 ± 30분.
-    # 윈도우: [어제 07:00 KST, 오늘 07:00 KST). 게시일 ≤ 당일 07:00 KST 필터.
-    - cron: "0 22 * * *"
+    # cron 트리거 KST 08:30 (UTC 23:30 전일) → 실제 실행 ~KST 11:54 → 발송 ~KST 12:00 ± 30분.
+    # 윈도우: [어제 08:30 KST, 오늘 08:30 KST). 게시일 ≤ 당일 08:30 KST 필터.
+    # 주의: WINDOW_END_HOUR/MINUTE 와 트리거 시각은 동기화 필요 — compute_window 가
+    # `end > now` 일 때 윈도우를 하루 뒤로 미는 분기를 갖고 있어, 트리거가 윈도우 종료보다
+    # 앞서 정시 발사되면 잘못된 날짜를 발송하게 됨.
+    - cron: "30 23 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -67,8 +70,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
-          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '7' }}
-          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '0' }}
+          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '8' }}
+          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '30' }}
           ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # 이메일 채널: GitHub Issue 경유가 아닌 SMTP 로 직접 발송 → 수신자 입장에서 GitHub 흔적 0.
           # 레거시 운영과 동일한 secret 명 재사용 (EMAIL_SENDER/EMAIL_PASSWORD/EMAIL_RECEIVER).

--- a/briefing/config.py
+++ b/briefing/config.py
@@ -29,13 +29,13 @@ KEYWORDS: tuple[str, ...] = (
     "E-7", "F-2", "F-4", "F-5", "F-6", "D-8", "D-10",
 )
 
-# 브리핑 윈도우: 매일 [어제 07:00 KST, 오늘 07:00 KST] 24시간 구간을 센싱.
-# 워크플로우는 매일 07:00 KST (UTC 22:00 전일, cron "0 22 * * *")에 트리거되며,
-# GitHub Actions 무료 cron 의 ~3시간 지연을 활용해 KST 10시 무렵 발송 도착을 목표.
-# 게시일 ≤ 당일 07:00 KST 조건을 만족하는 글만 수집해 즉시 발송.
+# 브리핑 윈도우: 매일 [어제 08:30 KST, 오늘 08:30 KST] 24시간 구간을 센싱.
+# 워크플로우는 매일 08:30 KST (UTC 23:30 전일, cron "30 23 * * *")에 트리거되며,
+# GitHub Actions 무료 cron 의 ~3시간 지연을 활용해 KST 12시 무렵 발송 도착을 목표.
+# 게시일 ≤ 당일 08:30 KST 조건을 만족하는 글만 수집해 즉시 발송.
 WINDOW_HOURS = int(os.getenv("WINDOW_HOURS", "24"))
-WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "7"))
-WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "0"))
+WINDOW_END_HOUR_KST = int(os.getenv("WINDOW_END_HOUR_KST", "8"))
+WINDOW_END_MINUTE_KST = int(os.getenv("WINDOW_END_MINUTE_KST", "30"))
 
 
 def compute_window(now: datetime | None = None) -> tuple[datetime, datetime]:


### PR DESCRIPTION
## Summary
- 브리핑 윈도우를 `[어제 07:00, 오늘 07:00)` → `[어제 08:30, 오늘 08:30)` KST 로 이동
- cron 트리거를 윈도우 종료에 맞춰 UTC `0 22 * * *` → `30 23 * * *` (KST 07:00 → 08:30)
- GitHub Actions cron 지연 기준 발송 시각 추정 ~KST 12:00 (기존 ~10:30 대비 ~1.5h 늦어짐)

## Why
사용자가 "전일 8:30 ~ 발송 당일 8:30" 윈도우를 요청. 윈도우 종료만 옮기면 `compute_window` 의 `end > now` 분기 때문에 정시 발사 시 윈도우가 하루 뒤로 밀리는 버그가 발생하므로 cron 도 함께 동기화.

## Test plan
- [ ] PR 머지 후 다음 KST 08:30 트리거가 정상 발사되는지 `gh run list --workflow=daily-briefing.yml` 로 확인
- [ ] 실제 발송 메일의 윈도우 표시(상단 헤더)가 08:30 ~ 08:30 KST 로 표기되는지 확인
- [ ] workflow_dispatch 수동 실행 시 윈도우 종료가 08:30 으로 계산되는지 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)