### PR TITLE
브리핑 윈도우: 08:30 → 07:00 KST 종료

### DIFF
--- a/.github/workflows/daily-briefing.yml
+++ b/.github/workflows/daily-briefing.yml
@@ -2,14 +2,14 @@ name: Daily Immigration Policy Briefing
 
 on:
   schedule:
-    # 윈도우 종료는 KST 08:30 — 트리거 시각을 윈도우 종료에 맞춤.
-    # GitHub Actions 무료 cron 은 평균 ~3시간 24분 지연되므로,
-    # cron 트리거 KST 08:30 (UTC 23:30 전일) → 실제 실행 ~KST 11:54 → 발송 ~KST 12:00 ± 30분.
-    # 윈도우: [어제 08:30 KST, 오늘 08:30 KST). 게시일 ≤ 당일 08:30 KST 필터.
+    # 윈도우 종료는 KST 07:00 — 트리거 시각을 윈도우 종료에 맞춤.
+    # GitHub Actions 무료 cron 은 평균 ~25분 지연되므로 (이 리포 22:30 UTC cron 과거 데이터 기준),
+    # cron 트리거 KST 07:00 (UTC 22:00 전일) → 실제 실행 ~KST 07:25 → 발송 ~KST 07:30, 늦어도 KST 09:30 이전.
+    # 윈도우: [어제 07:00 KST, 오늘 07:00 KST). 게시일 ≤ 당일 07:00 KST 필터.
     # 주의: WINDOW_END_HOUR/MINUTE 와 트리거 시각은 동기화 필요 — compute_window 가
     # `end > now` 일 때 윈도우를 하루 뒤로 미는 분기를 갖고 있어, 트리거가 윈도우 종료보다
     # 앞서 정시 발사되면 잘못된 날짜를 발송하게 됨.
-    - cron: "30 23 * * *"
+    - cron: "0 22 * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -70,8 +70,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_MODEL: ${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}
           WINDOW_HOURS: ${{ vars.WINDOW_HOURS || '24' }}
-          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '8' }}
-          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '30' }}
+          WINDOW_END_HOUR_KST: ${{ vars.WINDOW_END_HOUR_KST || '7' }}
+          WINDOW_END_MINUTE_KST: ${{ vars.WINDOW_END_MINUTE_KST || '0' }}
           ISSUE_KEEP_DAYS: ${{ vars.ISSUE_KEEP_DAYS || '30' }}
           # 이메일 채널: GitHub Issue 경유가 아닌 SMTP 로 직접 발송 → 수신자 입장에서 GitHub 흔적 0.
           # 레거시 운영과 동일한 secret 명 재사용 (EMAIL_SENDER/EMAIL_PASSWORD/EMAIL_RECEIVER).


### PR DESCRIPTION
## Summary
- 윈도우 종료 KST 08:30 → 07:00 (사용자가 매일 07:00까지 취합본을 09:30 이전에 받기를 원함)
- cron 트리거 `30 23 * * *` (UTC 23:30) → `0 22 * * *` (UTC 22:00 = KST 07:00 전일) — 윈도우 종료와 동기화
- `WINDOW_END_HOUR_KST` 기본값 `'8'`→`'7'`, `WINDOW_END_MINUTE_KST` 기본값 `'30'`→`'0'`
- 도착 예상: 이 리포 22:30 UTC cron 과거 실행 데이터(16~25분 지연) 기준 KST 07:25 ± 발송 → deadline 09:30 안전마진 확보

## 변경 이력 맥락
- PR #48 (10→9시) → PR #49 (9→7시) → PR #50 (7→08:30, 2026-05-18) → 본 PR (08:30→07:00)
- PR #50 머지 직후 자동 schedule 두 사이클 누락(5/18·5/19) 사례 있음 — 본 PR 머지 후 첫 자동 사이클도 누락 가능, 발생 시 `gh workflow run daily-briefing.yml`로 수동 트리거 권장

## Test plan
- [ ] 머지 후 다음 KST 07:00 트리거 발사 여부 확인 (`gh run list --workflow=daily-briefing.yml`)
- [ ] 도착 시각이 09:30 이전인지 모니터링
- [ ] 윈도우가 정상 계산되는지 (`compute_window` 분기 안 걸리는지) 로그에서 윈도우 범위 확인