### PR TITLE
제목에서 정부 CMS '새글작성' 배지 제거

### DIFF
--- a/briefing/scraper.py
+++ b/briefing/scraper.py
@@ -16,6 +16,11 @@ log = logging.getLogger(__name__)
 
 DATE_RE = re.compile(r"(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})")
 
+# 정부 통합 CMS(법무부·출입국 등)는 신규 게시글에 <span class="newArtcl">새글작성</span>
+# 배지를 제목 링크 안에 박아둔다. get_text 시 제목 뒤에 "새글작성" 이 딸려오므로
+# row 단계에서 미리 제거. 다른 보조 배지 클래스가 추가되면 셀렉터에 콤마로 잇는다.
+TITLE_BADGE_SELECTOR = "span.newArtcl"
+
 
 @dataclass
 class Article:
@@ -122,6 +127,9 @@ def _parse_list(
     latest_date = window_end.date()
 
     for row in rows[:max_rows]:
+        for badge in row.select(TITLE_BADGE_SELECTOR):
+            badge.decompose()
+
         link = _select_first(row, site.title_link_selector)
         if not link:
             continue


### PR DESCRIPTION
## Summary
법무부 보도자료(`https://www.moj.go.kr/moj/221/subview.do`)와 출입국·외국인정책본부 보도자료는 정부 통합 CMS를 공유하는데, 신규 게시글의 제목 링크 내부에 `<span class="newArtcl">새글작성</span>` 배지를 박아둠. `link.get_text(" ", strip=True)`가 이를 함께 긁어와 제목 끝에 "새글작성"이 노출되던 문제.

`_parse_list`의 row 루프 시작 지점에서 `span.newArtcl` 배지를 `decompose()`로 제거 → 이후 제목 추출 및 `_extract_content` 경로 모두에 적용됨.

## 변경
- `briefing/scraper.py`
  - 모듈 상수 `TITLE_BADGE_SELECTOR = "span.newArtcl"` 추가 (다른 배지 클래스 발견 시 콤마로 확장)
  - 각 row 진입 시 배지 decompose

## Test plan
- [ ] 머지 후 워크플로우 수동 트리거 (또는 다음 자동 트리거) → 메일 제목에 "새글작성" 미포함 확인
- [ ] 하이코리아 공지사항·MSIT(보존된 코드) 제목은 영향 없음 — 셀렉터가 정부 통합 CMS 전용 클래스이므로 안전