### PR TITLE
fix(briefing): KDI EIEC SSL 검증 우회 — intermediate cert 누락

### DIFF
--- a/briefing/config.py
+++ b/briefing/config.py
@@ -83,6 +83,10 @@ class Site:
     # AJAX 로 행 데이터가 채워지는 사이트 — Playwright 가 이 selector 가 비어있지 않을
     # 때까지 추가 대기.
     wait_selector: str | None = None
+    # KDI EIEC 등 일부 정부 사이트는 서버가 intermediate cert 를 같이 내려주지 않아
+    # requests 의 기본 CA 번들 검증에 실패한다(브라우저는 AIA fetching 으로 해결).
+    # 콘텐츠 무결성만 신뢰 경계인 공개 읽기 전용 사이트에 한해 False 로 둠.
+    verify_ssl: bool = True
 
 
 # 신규 보도자료/공지 수집 소스 5곳:
@@ -150,6 +154,7 @@ SITES: tuple[Site, ...] = (
         title_selector="div.list_txt p",
         date_selector="div.list_txt span:nth-of-type(2)",
         detail_content_selector="div.view_body, div.view_comm_style",
+        verify_ssl=False,
     ),
     Site(
         # KDI EIEC '국내자료' — 국내 연구기관 보고서/이슈페이퍼 큐레이션.
@@ -162,6 +167,7 @@ SITES: tuple[Site, ...] = (
         title_selector="div.list_txt p",
         date_selector="div.list_txt span:nth-of-type(2)",
         detail_content_selector="div.view_body, div.view_comm_style",
+        verify_ssl=False,
     ),
 )
 

--- a/briefing/http_client.py
+++ b/briefing/http_client.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import logging
 
 import requests
+import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .config import REQUEST_RETRIES, REQUEST_TIMEOUT, USER_AGENT
+
+# verify=False 호출은 KDI 등 intermediate cert 누락 정부 사이트 한정. 매 요청마다
+# InsecureRequestWarning 이 로그를 더럽히지 않게 한 번만 끈다.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 log = logging.getLogger(__name__)
 
@@ -26,9 +31,15 @@ def make_session() -> requests.Session:
     return session
 
 
-def get(session: requests.Session, url: str, *, encoding: str | None = None) -> requests.Response | None:
+def get(
+    session: requests.Session,
+    url: str,
+    *,
+    encoding: str | None = None,
+    verify: bool = True,
+) -> requests.Response | None:
     try:
-        res = session.get(url, timeout=REQUEST_TIMEOUT)
+        res = session.get(url, timeout=REQUEST_TIMEOUT, verify=verify)
         res.raise_for_status()
     except requests.RequestException as exc:
         log.warning("GET %s failed: %s", url, exc)

--- a/briefing/scraper.py
+++ b/briefing/scraper.py
@@ -205,14 +205,14 @@ def fetch_articles(session, site: Site, *, max_rows: int = 15, js_renderer=None)
             return result
         return _parse_list(list_html, site, max_rows, fetch_detail=js_renderer.fetch)
 
-    res = get(session, site.list_url, encoding=site.encoding)
+    res = get(session, site.list_url, encoding=site.encoding, verify=site.verify_ssl)
     if res is None:
         result = ScrapeResult()
         result.errors.append((site.name, "목록 페이지 접속 실패 (네트워크 또는 5xx)"))
         return result
 
     def static_detail(url: str) -> Optional[str]:
-        d = get(session, url, encoding=site.encoding)
+        d = get(session, url, encoding=site.encoding, verify=site.verify_ssl)
         return d.text if d is not None else None
 
     return _parse_list(res.text, site, max_rows, fetch_detail=static_detail)


### PR DESCRIPTION
## Summary
PR #54 머지 후 수동 트리거(run #26628781419)에서 KDI 두 사이트가 SSL 오류로 페치 실패. KDI EIEC 서버가 `Thawte TLS RSA CA G1` intermediate cert 를 응답에 포함시키지 않아 \`requests\` 의 기본 CA 검증이 실패 (브라우저는 AIA fetching 으로 자동 해결, requests 는 미지원).

## 변경
- `Site` 데이터클래스에 `verify_ssl: bool = True` 플래그 추가
- KDI 정책자료, KDI 국내자료 두 사이트만 \`verify_ssl=False\` 로 설정
- `http_client.get` 에 \`verify\` 인자 추가, scraper 가 \`site.verify_ssl\` 을 그대로 전달
- 모듈 로드 시 \`InsecureRequestWarning\` 1회 disable (로그 정리)
- **다른 사이트의 SSL 검증은 그대로 유지**

## 신뢰 경계
- 공개 읽기 전용 정부 사이트 (자격증명·세션 토큰 미전송)
- 리스크: MITM 이 가짜 콘텐츠를 끼워넣을 경우 잘못된 정보가 메일에 노출될 수 있음 (콘텐츠 무결성 손상)
- 사용자 명시 승인하에 적용

## 로컬 검증
- KDI 정책자료: errors 0, matched 2 (외국인 증권투자 동향, 외국인 토지·주택 보유통계), 상세 본문 정상 수집
- KDI 국내자료: errors 0, matched 0 (오늘 키워드 매칭 없음, 정상)

## Test plan
- [ ] 머지 후 수동 트리거하여 errors 라인에 KDI SSL 에러가 없는지 확인
- [ ] 메일 본문에 KDI 출처 글이 있는지 (있다면) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)