### PR TITLE
브리핑 본문에서 '모니터링 경고' 섹션 숨김

### DIFF
--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -154,14 +154,8 @@ def render_markdown(
                 lines.append("> (첨부 파일 메타 추출 실패 — 페이지 직접 확인 권장)")
             lines.append("")
 
-    if scrape_errors:
-        lines.append("---")
-        lines.append("")
-        lines.append("## ⚠️ 모니터링 경고")
-        lines.append("")
-        for site, msg in scrape_errors:
-            lines.append(f"- **{site}**: {msg}")
-        lines.append("")
+    # 모니터링 경고 섹션은 사용자 요청으로 메일/브리핑 본문에서 숨김 처리.
+    # (스크레이프 에러는 액션 로그에만 남고 수신자에게는 노출하지 않음)
 
     return title, "\n".join(lines).rstrip() + "\n"
 


### PR DESCRIPTION
## 변경 내용
일일 브리핑 메일/이슈 본문 하단에 표시되던 **⚠️ 모니터링 경고** 섹션을 숨깁니다.

- `render_markdown`에서 `scrape_errors`를 본문에 렌더하던 블록 제거
- 스크레이프 에러 정보는 GitHub Actions 로그에는 그대로 남으므로, 운영 진단에는 영향 없음
- 수신자에게 노출되는 본문에서만 사라짐

## 이유
사용자 요청 — 수신자에게 보이는 브리핑에서 모니터링 경고가 노출되지 않도록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)