### PR TITLE
브리핑 하단에 '센싱 키워드' 안내 추가

### DIFF
--- a/briefing/publisher.py
+++ b/briefing/publisher.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 import requests
 
-from .config import KST, SITES, TRACKED_PAGES
+from .config import KEYWORDS, KST, SITES, TRACKED_PAGES
 
 log = logging.getLogger(__name__)
 
@@ -156,6 +156,17 @@ def render_markdown(
 
     # 모니터링 경고 섹션은 사용자 요청으로 메일/브리핑 본문에서 숨김 처리.
     # (스크레이프 에러는 액션 로그에만 남고 수신자에게는 노출하지 않음)
+
+    # 본문 하단: 어떤 키워드로 글을 센싱하는지 간단 안내.
+    # config.KEYWORDS 와 자동 동기화되므로 키워드 추가/삭제 시 함께 갱신됨.
+    lines.append("---")
+    lines.append("")
+    lines.append("## 🔎 센싱 키워드")
+    lines.append("")
+    lines.append("아래 키워드가 제목·본문에 포함된 정부·기관 게시물을 자동으로 수집·요약합니다.")
+    lines.append("")
+    lines.append("> " + " · ".join(KEYWORDS))
+    lines.append("")
 
     return title, "\n".join(lines).rstrip() + "\n"
 


### PR DESCRIPTION
## 변경 내용
일일 브리핑 본문 맨 아래에 **🔎 센싱 키워드** 섹션을 추가합니다.

- 어떤 키워드로 정부·기관 게시물을 수집·요약하는지 수신자에게 간단히 안내
- `config.KEYWORDS`를 그대로 끌어와 렌더 → 키워드 추가/삭제 시 자동 동기화 (하드코딩 아님)

## 예시 출력
> 이민 · 비자 · 사증 · 외국인 · 출입국 · 입국 · 국적 · 체류 · 영주 · 귀화 · 난민 · 이주 · 유학생 · 고용허가 · 계절근로자 · 워킹홀리데이 · 전자여행허가 · K-ETA · 재외동포 · 재외국민 · 다문화 · 사회통합 · KIIP · 인재유치 · 우수인재 · 고급인재 · E-7 · F-2 · F-4 · F-5 · F-6 · D-8 · D-10

🤖 Generated with [Claude Code](https://claude.com/claude-code)